### PR TITLE
Version 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
-__This software is in its very early days, and is not guaranteed to work well. Use at your own risk.__
-
 # PDFPlumber
 
-Plumb a PDF for detailed information about each text character, rectangle, and line. Works best on machine-generated, rather than scanned, PDFs. Built on [`pdfminer`](https://github.com/euske/pdfminer) and [`pdfminer.six`](https://github.com/goulu/pdfminer).
+Plumb a PDF for detailed information about each text character, rectangle, and line. Plus: Easily extract data from tables trapped in PDFs.
+
+Works best on machine-generated, rather than scanned, PDFs. Built on [`pdfminer`](https://github.com/euske/pdfminer) and [`pdfminer.six`](https://github.com/goulu/pdfminer).
 
 - [Installation](#installation)
 - [Command Line Interface](#command-line-interface)
 - [Python Library](#python-library)
+- [Extracting tables](#extracting-tables)
 - [Demos](#demos)
 
 ## Installation
@@ -29,6 +30,7 @@ The output will be a CSV containing info about every character, line, and rectan
 ### Options
 
 - `--format [format]`: `csv` or `json`
+    - The `json` format returns slightly more information; it includes PDF-level metadata and height/width information about each page.
 - `--pages [list of pages]`: A space-delimited, `1`-indexed list of pages or hyphenated page ranges. E.g., `1, 11-15`, which would return data for pages 1, 11, 12, 13, 14, and 15.
 - `--types [list of object types to extract]`: Choices are `char`, `anno`, `line`, `rect`, `rect_edge`. Defaults to `char`, `anno`, `line`, `rect`.
 
@@ -40,15 +42,9 @@ The output will be a CSV containing info about every character, line, and rectan
 import pdfplumber
 
 pdf = pdfplumber.from_path("path/to/file.pdf")
+first_page = pdf.pages[0]
 
-if len(pdf.chars):
-    print(pdf.chars[0])
-
-if len(pdf.rects):
-    print(pdf.rects[0])
-
-if len(pdf.lines):
-    print(pdf.lines[0])
+print(first_page.chars[0])
 ```
 
 ### Loading a PDF
@@ -56,20 +52,47 @@ if len(pdf.lines):
 `pdfplumber` provides two main ways to load a PDF:
 
 - `pdfplumber.load(file_like_object)`
+
 - `pdfplumber.from_path("path/to/file.pdf")`
 
 Both methods return an instance of the `pdfplumber.PDF` class.
 
+### The `pdfplumber.PDF` class
+
+The top-level `pdfplumber.PDF` class represents a single PDF and has two main properties:
+
+- `.metadata`: A dictionary of metadata key/value pairs, drawn from the PDF's `Info` trailers. Typically includes "CreationDate," "ModDate," "Producer," et cetera.
+
+- `.pages`: A list containing one `pdfplumber.Page` instance per page loaded.
+
+### The `pdfplumber.Page` class
+
+The `pdfplumber.Page` class is at the core of `pdfplumber`. Most things you'll do with `pdfplumber` will revolve around this class. It has these main methods and properties:
+
+- `.pageid`: The internal ID assigned to this page. Often, this number will correspond to the page number, but not necessarily.
+
+- `.width`: The page's width.
+
+- `.height`: The page's height.
+
+- `.objects` / `.chars` / `.lines` / `.rects`: Each of these properties is a list, and each list contains one dictionary for each such object embedded on the page. For more detail, see "[Objects](#objects)" below.
+
+- `.crop(bounding_box, strict=False)`: Returns a version of the page cropped to the bounding box, which should be expressed as 4-tuple with the values `(x0, top, x1, bottom)`.
+    - By default, the cropped page retains objects that fall at least partly within the bounding box. If an object falls only partly within the box, its dimensions are sliced to fit the bounding box.
+    - Calling `.crop` with `strict=True`, however, retains only objects that fall *entirely* within the bounding box.
+
+- `.collate_chars(x_tolerance=0, y_tolerance=0)`: Collates all of the page's character objects into a single string. Adds spaces where the difference between the `x1` of one character and the `x0` of the next is greater than `x_tolerance`. Adds newline characters where the difference between the `doctop` of one character and the `doctop` of the next is greater than `y_tolerance`.
+
+- `.extract_table(...)`: Extracts tabular data from the page. For more details see "[Extracting tables](#extracting-tables)" below.
+
 ### Objects
 
-Each instance of `pdfplumber.PDF` provides access to six types of PDF objects. The following properties each return a Python list of the matching objects:
+Each instance of `pdfplumber.PDF` and `pdfplumber.Page` provides access to four types of PDF objects. The following properties each return a Python list of the matching objects:
 
 - `.chars`, each representing a single text character.
 - `.annos`, each representing a single annotation-text character.
 - `.lines`, each representing a single 1-dimensional line.
 - `.rects`, each representing a single 2-dimensional rectangle.
-
-### Object Properties
 
 Each object is represented as a simple Python `dict`, with the following properties:
 
@@ -87,6 +110,7 @@ Each object is represented as a simple Python `dict`, with the following propert
     - `y0`: Distance of bottom of character from bottom of page.
     - `y1`: Distance of top of character from bottom of page.
     - `top`: Distance of top of character from top of page.
+    - `bottom`: Distance of bottom of the character from top of page.
     - `doctop`: Distance of top of character from top of document.
     - `object_type`: "char" / "anno"
 
@@ -99,6 +123,7 @@ Each object is represented as a simple Python `dict`, with the following propert
     - `y0`: Distance of bottom extremity from bottom of page.
     - `y1`: Distance of top extremity bottom of page.
     - `top`: Distance of top of line from top of page.
+    - `bottom`: Distance of bottom of the line from top of page.
     - `doctop`: Distance of top of line from top of document.
     - `linewidth`: Thickness of line.
     - `object_type`: "line"
@@ -112,23 +137,38 @@ Each object is represented as a simple Python `dict`, with the following propert
     - `y0`: Distance of bottom of rectangle from bottom of page.
     - `y1`: Distance of top of rectangle from bottom of page.
     - `top`: Distance of top of rectangle from top of page.
+    - `bottom`: Distance of bottom of the rectangle from top of page.
     - `doctop`: Distance of top of rectangle from top of document.
     - `linewidth`: Thickness of line.
     - `object_type`: "rect"
 
-### Utils / Helpers
+Additionally, both `pdfplumber.PDF` and `pdfplumber.Page` provide access to two derived lists of objects: `.rect_edges` (which decomposes each rectangle into its four lines) and `.edges` (which combines `.rect_edges` with `.lines`). 
 
-The `pdfplumber` Python library comes with a set of useful helper methods, accessible via `pdfplumber.utils`. They are:
+## Extracting Tables
 
-- __`collate_chars(chars, x_tolerance=0, y_tolerance=0)`__: Takes a list or dataframe of character objects and condenses them into a single string. Adds spaces where the difference between the `x1` of one character and the `x0` of the next is greater than `x_tolerance`. Adds newline characters where the difference between the `doctop` of one character and the `doctop` of the next is greater than `y_tolerance`.
+You can think of `Page.extract_table(...)` as a sort of scriptable [Tablula](http://tabula.technology/). Given a page or cropped page, this method will return a list of lists representing the extracted table. By default, `extract_table` uses the page's vertical and horizontal lines (or rectangle edges) as cell-separators. But the method is highly customizable via these keyword arguments:
 
-- __`extract_columns(chars, x_tolerance=0, y_tolerance=0, gutter_min_width=5)`__: Takes a list or dataframe of chars, looks for columns — vertical clumps of text separated by vertical "gutters" of non-text — and returns a representation of those columns. Passes `x_tolerance` and `y_tolerance` to `collate_chars(...)` (see above). Considers characters whose `doctop`s are within `y_tolerance` of one another to be on the same "line". For a gutter to be detected, it must be at least `gutter_min_width` pixels wide and have no character begin or end within it.
+- `v=[strategy_name]`: Strategy for locating vertical dividers. Defaults to "lines," which uses lines and rectangle edges. Other options: "lines_strict," which only uses lines (and not rectangle edges), and "gutters," which looks for vertical sections of the document with no text in them.
 
-- __`within_bbox(objs, bbox)`__: Takes a list or dataframe of objects (`chars`, `rects`, etc.) and returns those that are fully contained within a `bbox` of `(x0, top0, x1, top1)`.
+- `h=[strategy_name]`: Strategy for locating horizontal dividers. Same defaults/options as `v`.
+
+- `line_min_height=[number]`: The minimum height a line must be before being used in the vertical "lines" strategy. Defaults to `1`.
+
+- `line_min_width=[number]`: The minimum width a line must be before being used in the horizontal "lines" strategy. Defaults to `1`.
+
+- `gutter_min_width=[number]`: Minimum size of a character "gutter" to be used in the horizontal "gutters" strategy. Defaults to `5`.
+
+- `gutter_min_height=[number]`: Minimum size of a character "gutter" to be used in the vertical "gutters" strategy. Defaults to `5`.
+
+- `x_tolerance=[number]`: The maximum horizontal distance between two consecutive characters to consider them part of the same word. (Otherwise, a space is inserted between them.) Defaults to `0`.
+
+- `x_tolerance=[number]`: The maximum vertical distance between two consecutive characters to consider them part of the same line. (Otherwise, a newline is inserted between them.) Defaults to `0`.
+
+Note: Often it's helpful to crop a page before trying to extract the table. See the first demo below for an example.
 
 ## Demos
 
-- [Use `pdfplumber.utils` to extract data from the FBI's National Instant Criminal Background Check System PDFs.](examples/notebooks/utils-nics.ipynb)
+- [Use `extract_table` on the FBI's National Instant Criminal Background Check System PDFs.](examples/notebooks/utils-nics.ipynb)
 
 ## Python Support
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The output will be a CSV containing info about every character, line, and rectan
 
 - `--format [format]`: `csv` or `json`
 - `--pages [list of pages]`: A space-delimited, `1`-indexed list of pages or hyphenated page ranges. E.g., `1, 11-15`, which would return data for pages 1, 11, 12, 13, 14, and 15.
-- `--types [list of object types to extract]`: Choices are `char`, `anno`, `line`, `rect`. Defaults to all four.
+- `--types [list of object types to extract]`: Choices are `char`, `anno`, `line`, `rect`, `rect_edge`. Defaults to `char`, `anno`, `line`, `rect`.
 
 ## Python Library
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The `pdfplumber.Page` class is at the core of `pdfplumber`. Most things you'll d
     - By default, the cropped page retains objects that fall at least partly within the bounding box. If an object falls only partly within the box, its dimensions are sliced to fit the bounding box.
     - Calling `.crop` with `strict=True`, however, retains only objects that fall *entirely* within the bounding box.
 
-- `.collate_chars(x_tolerance=0, y_tolerance=0)`: Collates all of the page's character objects into a single string. Adds spaces where the difference between the `x1` of one character and the `x0` of the next is greater than `x_tolerance`. Adds newline characters where the difference between the `doctop` of one character and the `doctop` of the next is greater than `y_tolerance`.
+- `.get_text(x_tolerance=0, y_tolerance=0)`: Collates all of the page's character objects into a single string. Adds spaces where the difference between the `x1` of one character and the `x0` of the next is greater than `x_tolerance`. Adds newline characters where the difference between the `doctop` of one character and the `doctop` of the next is greater than `y_tolerance`.
 
 - `.extract_table(...)`: Extracts tabular data from the page. For more details see "[Extracting tables](#extracting-tables)" below.
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Note: Often it's helpful to crop a page before trying to extract the table. See 
 
 ## Demos
 
-- [Use `extract_table` on the FBI's National Instant Criminal Background Check System PDFs.](examples/notebooks/utils-nics.ipynb)
+- [Use `extract_table` on the FBI's National Instant Criminal Background Check System PDFs.](examples/notebooks/extract-table-nics.ipynb)
 
 ## Python Support
 

--- a/examples/notebooks/extract-table-nics.ipynb
+++ b/examples/notebooks/extract-table-nics.ipynb
@@ -4,16 +4,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Demonstration of `pdfplumber.utils`\n",
+    "# Demonstration of `pdfplumber`'s `extract_table` method.\n",
     "\n",
-    "This notebook uses our [example PDF](../pdfs/background-checks.pdf) from the FBI's National Instant Criminal Background Check System to demonstrate `pdfplumber.utils`."
+    "This notebook uses our [example PDF](../pdfs/background-checks.pdf) from the FBI's National Instant Criminal Background Check System."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Import `pdfplumber` and the relevant `utils`"
+    "### Import `pdfplumber`"
    ]
   },
   {
@@ -24,8 +24,7 @@
    },
    "outputs": [],
    "source": [
-    "import pdfplumber\n",
-    "from pdfplumber.utils import within_bbox, extract_columns, collate_chars"
+    "import pdfplumber"
    ]
   },
   {
@@ -50,7 +49,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### For use in constructing the bounding boxes later, store the the page width"
+    "### Get the first page"
    ]
   },
   {
@@ -61,14 +60,16 @@
    },
    "outputs": [],
    "source": [
-    "PDF_WIDTH = pdf.pages[0].width"
+    "page_1 = pdf.pages[0]"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Here are the first three characters stored in the PDF:"
+    "### Use `.crop` to focus on the main data table\n",
+    "\n",
+    "It starts around 80px from the top, and is about 405px tall. To select only these characters, we use `within_bbox`, and pass a bounding box of `(0, 80, PDF_WIDTH, 485)` as the `(x0, top, x1, bottom)` values."
    ]
   },
   {
@@ -77,26 +78,20 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[{'size': 11.414, 'width': 4.642, 'pageid': 1, 'x1': 51.682, 'object_type': 'char', 'top': 67.486, 'text': 'S', 'x0': 47.04, 'upright': True, 'y1': 544.514, 'y0': 533.099, 'height': 11.414, 'doctop': 67.486, 'fontname': 'DCLTEC+Helvetica-Bold', 'adv': 0.667}, {'size': 11.414, 'width': 2.318, 'pageid': 1, 'x1': 53.916, 'object_type': 'char', 'top': 67.486, 'text': 't', 'x0': 51.599, 'upright': True, 'y1': 544.514, 'y0': 533.099, 'height': 11.414, 'doctop': 67.486, 'fontname': 'DCLTEC+Helvetica-Bold', 'adv': 0.333}, {'size': 11.414, 'width': 3.87, 'pageid': 1, 'x1': 57.863, 'object_type': 'char', 'top': 67.486, 'text': 'a', 'x0': 53.993, 'upright': True, 'y1': 544.514, 'y0': 533.099, 'height': 11.414, 'doctop': 67.486, 'fontname': 'DCLTEC+Helvetica-Bold', 'adv': 0.556}]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "print(pdf.chars[:3])"
+    "table_crop = page_1.crop((0, 80, page_1.width, 485))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Use `within_bbox` to focus on the main data table\n",
+    "### Use `extract_table` to pull the data\n",
     "\n",
-    "It starts around 77px from the top, and is about 410px tall. To select only these characters, we use `within_bbox`, and pass a bounding box of `(0, 77, PDF_WIDTH, 485)` as the `(x0, top0, x1, top1)` values."
+    "- Because the columns are separated by lines, we use `v=\"lines\"`\n",
+    "- Because the rows are, primarily, separated by gutters, we use `h=\"gutters\"`\n",
+    "- And because side-by-side characters don't abut one another exactly, we use `x_tolerance=2`."
    ]
   },
   {
@@ -110,42 +105,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[{'size': 7.667, 'width': 3.842, 'pageid': 1, 'x1': 47.042, 'object_type': 'char', 'y0': 525.799, 'text': 'A', 'x0': 43.2, 'upright': True, 'y1': 533.465, 'top': 78.535, 'height': 7.667, 'doctop': 78.535, 'fontname': 'WEVZII+ArialMT', 'adv': 0.667}, {'size': 7.667, 'width': 1.279, 'pageid': 1, 'x1': 48.079, 'object_type': 'char', 'y0': 525.799, 'text': 'l', 'x0': 46.8, 'upright': True, 'y1': 533.465, 'top': 78.535, 'height': 7.667, 'doctop': 78.535, 'fontname': 'WEVZII+ArialMT', 'adv': 0.222}, {'size': 7.667, 'width': 3.203, 'pageid': 1, 'x1': 51.437, 'object_type': 'char', 'y0': 525.799, 'text': 'a', 'x0': 48.234, 'upright': True, 'y1': 533.465, 'top': 78.535, 'height': 7.667, 'doctop': 78.535, 'fontname': 'WEVZII+ArialMT', 'adv': 0.556}]\n"
+      "['Alabama', '18,870', '23,022', '22,650', '859', '1,178', '0', '14', '15', '0', '2,179', '2,307', '11', '0', '0', '0', None, None, '13', '14', '0', '3', '2', '0', '71,137']\n",
+      "['Alaska', '209', '3,062', '3,209', '191', '184', '0', '9', '3', '0', '100', '100', '0', '18', '9', '1', None, None, '0', '0', '0', '0', '0', '0', '7,095']\n",
+      "['Arizona', '2,303', '12,382', '9,041', '707', '618', '0', '5', '3', '0', '1,273', '648', '4', '76', '8', '1', None, None, '9', '6', '1', '1', '1', '0', '27,087']\n",
+      "['Arkansas', '3,298', '6,359', '11,611', '168', '376', '0', '12', '6', '1', '922', '2,275', '1', '0', '0', '0', None, None, '6', '12', '1', '0', '0', '0', '25,048']\n",
+      "['California', '98452', '41181', '35007', '4559', '0', '0', '0', '0', '0', '480', '433', '4', '0', '0', '0', None, None, '0', '0', '0', '0', '0', '0', '180116']\n"
      ]
     }
    ],
    "source": [
-    "table_chars = within_bbox(pdf.chars, (0, 77, PDF_WIDTH, 485))\n",
-    "print(table_chars[:3])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Use `extract_columns` to divide the characters into rows and columns\n",
-    "\n",
-    "Because side-by-side characters don't abut one another exactly, we pass `x_tolerance=2`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[{0: 'Alabama', 1: '18,870', 2: '23,022', 3: '22,650', 4: '859', 5: '1,178', 6: '0', 7: '14', 8: '15', 9: '0', 10: '2,179', 11: '2,307', 12: '11', 13: '0', 14: '0', 15: '0', 16: '', 17: '', 18: '13', 19: '14', 20: '0', 21: '3', 22: '2', 23: '0', 24: '71,137'}, {0: 'Alaska', 1: '209', 2: '3,062', 3: '3,209', 4: '191', 5: '184', 6: '0', 7: '9', 8: '3', 9: '0', 10: '100', 11: '100', 12: '0', 13: '18', 14: '9', 15: '1', 16: '', 17: '', 18: '0', 19: '0', 20: '0', 21: '0', 22: '0', 23: '0', 24: '7,095'}]\n"
-     ]
-    }
-   ],
-   "source": [
-    "table = extract_columns(table_chars, x_tolerance=2)\n",
-    "print(table[:2])"
+    "table = table_crop.extract_table(v=\"lines\", h=\"gutters\", x_tolerance=2)\n",
+    "for row in table[:5]:\n",
+    "    print(row)"
    ]
   },
   {
@@ -159,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {
     "collapsed": true
    },
@@ -196,33 +167,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
-    "def parse_value(k, x):\n",
-    "    if k == 0: return x\n",
-    "    if x == \"\": return None\n",
+    "def parse_value(i, x):\n",
+    "    if i == 0: return x\n",
+    "    if x == None: return None\n",
     "    return int(x.replace(\",\", \"\"))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
     "def parse_row(row):\n",
-    "    return dict((COLUMNS[k], parse_value(k, v)) for k, v in row.items())"
+    "    return dict((COLUMNS[i], parse_value(i, cell))\n",
+    "        for i, cell in enumerate(row))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -235,12 +207,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here's a sample row:"
+    "Here's the first row, parsed:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
@@ -248,40 +220,40 @@
     {
      "data": {
       "text/plain": [
-       "{'admin': 1,\n",
-       " 'handgun': 1745,\n",
-       " 'long_gun': 2372,\n",
-       " 'multiple': 104,\n",
-       " 'other': 87,\n",
-       " 'permit': 383,\n",
-       " 'prepawn_handgun': 0,\n",
-       " 'prepawn_long_gun': 4,\n",
+       "{'admin': 0,\n",
+       " 'handgun': 23022,\n",
+       " 'long_gun': 22650,\n",
+       " 'multiple': 1178,\n",
+       " 'other': 859,\n",
+       " 'permit': 18870,\n",
+       " 'prepawn_handgun': 14,\n",
+       " 'prepawn_long_gun': 15,\n",
        " 'prepawn_other': 0,\n",
-       " 'private_sale_handgun': 1,\n",
-       " 'private_sale_long_gun': 2,\n",
+       " 'private_sale_handgun': 13,\n",
+       " 'private_sale_long_gun': 14,\n",
        " 'private_sale_other': 0,\n",
-       " 'redemption_handgun': 132,\n",
-       " 'redemption_long_gun': 184,\n",
-       " 'redemption_other': 0,\n",
+       " 'redemption_handgun': 2179,\n",
+       " 'redemption_long_gun': 2307,\n",
+       " 'redemption_other': 11,\n",
        " 'rentals_handgun': None,\n",
        " 'rentals_long_gun': None,\n",
-       " 'return_to_seller_handgun': 0,\n",
+       " 'return_to_seller_handgun': 3,\n",
        " 'return_to_seller_long_gun': 2,\n",
        " 'return_to_seller_other': 0,\n",
        " 'returned_handgun': 0,\n",
        " 'returned_long_gun': 0,\n",
        " 'returned_other': 0,\n",
-       " 'state': 'Wyoming',\n",
-       " 'totals': 5017}"
+       " 'state': 'Alabama',\n",
+       " 'totals': 71137}"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "parsed_table[-2]"
+    "parsed_table[0]"
    ]
   },
   {
@@ -295,7 +267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
@@ -322,25 +294,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Use `within_bbox` and `collate_chars` to extract the report month\n",
+    "### Use `collate_chars` to extract the report month\n",
     "\n",
-    "The month of the report is listed in an area 35px to 60px from the top of the page. The code below isolates characters in that space, and then collates their text."
+    "It looks like the month of the report is listed in an area 35px to 65px from the top of the page. But there's also some other text directly above and below it. So when we crop for that area, we'll use `strict=True` to select only characters (and other objects) that are fully within the crop-box."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "month_crop = page_1.crop((0, 35, page_1.width, 65), strict=True)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "month_chars = within_bbox(pdf.chars, (0, 35, PDF_WIDTH, 60))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
    "metadata": {
     "collapsed": false
    },
@@ -351,13 +323,14 @@
        "'November - 2015'"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "collate_chars(month_chars, x_tolerance=2)"
+    "month_chars = month_crop.collate_chars(x_tolerance=2, y_tolerance=2)\n",
+    "month_chars"
    ]
   },
   {

--- a/examples/notebooks/extract-table-nics.ipynb
+++ b/examples/notebooks/extract-table-nics.ipynb
@@ -294,7 +294,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Use `collate_chars` to extract the report month\n",
+    "### Use `get_text` to extract the report month\n",
     "\n",
     "It looks like the month of the report is listed in an area 35px to 65px from the top of the page. But there's also some other text directly above and below it. So when we crop for that area, we'll use `strict=True` to select only characters (and other objects) that are fully within the crop-box."
    ]
@@ -329,7 +329,7 @@
     }
    ],
    "source": [
-    "month_chars = month_crop.collate_chars(x_tolerance=2, y_tolerance=2)\n",
+    "month_chars = month_crop.get_text(x_tolerance=2, y_tolerance=2)\n",
     "month_chars"
    ]
   },

--- a/pdfplumber/__init__.py
+++ b/pdfplumber/__init__.py
@@ -5,7 +5,7 @@ import pdfminer.pdftypes
 pdfminer.pdftypes.STRICT = False
 pdfminer.pdfinterp.STRICT = False
 
-VERSION_TUPLE = (0, 2, 0)
+VERSION_TUPLE = (0, 3, 0)
 VERSION = ".".join(map(str, VERSION_TUPLE))
 
 def load(file_or_buffer, **kwargs):

--- a/pdfplumber/__init__.py
+++ b/pdfplumber/__init__.py
@@ -12,8 +12,7 @@ def load(file_or_buffer, **kwargs):
     return PDF(file_or_buffer, **kwargs)
 
 def from_path(path, **kwargs):
-    with open(path, "rb") as f:
-        return PDF(f, **kwargs)
+    return PDF(open(path, "rb"), **kwargs)
 
 def set_debug(debug=0):
     pdfminer.debug = debug

--- a/pdfplumber/cli.py
+++ b/pdfplumber/cli.py
@@ -23,7 +23,7 @@ def parse_args():
         default="csv")
 
     parser.add_argument("--types", nargs="+",
-        choices=[ "char", "anno", "line", "rect" ],
+        choices=[ "char", "anno", "line", "rect", "rect_edge" ],
         default=[ "char", "anno", "line", "rect" ])
 
     parser.add_argument("--pages", nargs="+",

--- a/pdfplumber/container.py
+++ b/pdfplumber/container.py
@@ -31,7 +31,7 @@ def rect_to_edges(rect):
 
 def line_to_edge(line):
     edge = dict(line)
-    edge["is_horizontal"] = line["y0"] == line["y1"]
+    edge["orientation"] = "h" if (line["y0"] == line["y1"]) else "v"
     return edge
 
 class Container(object):

--- a/pdfplumber/container.py
+++ b/pdfplumber/container.py
@@ -3,26 +3,26 @@ from itertools import chain
 def rect_to_edges(rect):
     top, bottom, left, right = [ dict(rect) for x in range(4) ]
     top.update({
-        "object_type": "edge_top",
+        "object_type": "rect_edge",
         "height": 0,
         "y0": rect["y1"],
         "orientation": "h"
     })
     bottom.update({
-        "object_type": "edge_bottom",
+        "object_type": "rect_edge",
         "height": 0,
         "doctop": rect["doctop"] + rect["height"],
         "y1": rect["y0"],
         "orientation": "h"
     })
     left.update({
-        "object_type": "edge_left",
+        "object_type": "rect_edge",
         "width": 0,
         "x1": rect["x0"],
         "orientation": "v"
     })
     right.update({
-        "object_type": "edge_right",
+        "object_type": "rect_edge",
         "width": 0,
         "x0": rect["x1"],
         "orientation": "v"

--- a/pdfplumber/container.py
+++ b/pdfplumber/container.py
@@ -1,0 +1,67 @@
+from itertools import chain
+
+def rect_to_edges(rect):
+    top, bottom, left, right = [ dict(rect) for x in range(4) ]
+    top.update({
+        "object_type": "edge_top",
+        "height": 0,
+        "y0": rect["y1"],
+        "orientation": "h"
+    })
+    bottom.update({
+        "object_type": "edge_bottom",
+        "height": 0,
+        "doctop": rect["doctop"] + rect["height"],
+        "y1": rect["y0"],
+        "orientation": "h"
+    })
+    left.update({
+        "object_type": "edge_left",
+        "width": 0,
+        "x1": rect["x0"],
+        "orientation": "v"
+    })
+    right.update({
+        "object_type": "edge_right",
+        "width": 0,
+        "x0": rect["x1"],
+        "orientation": "v"
+    })
+    return [ top, bottom, left, right ]
+
+def line_to_edge(line):
+    edge = dict(line)
+    edge["is_horizontal"] = line["y0"] == line["y1"]
+    return edge
+
+class Container(object):
+    @property
+    def rects(self):
+        return self.objects.get("rect", [])
+
+    @property
+    def lines(self):
+        return self.objects.get("line", [])
+
+    @property
+    def images(self):
+        return self.objects.get("image", [])
+
+    @property
+    def figures(self):
+        return self.objects.get("figure", [])
+
+    @property
+    def chars(self):
+        return self.objects.get("char", [])
+
+    @property
+    def annos(self):
+        return self.objects.get("anno", [])
+
+    @property
+    def edges(self):
+        rect_edges_gen = (rect_to_edges(r) for r in self.rects)
+        rect_edges = list(chain(*rect_edges_gen))
+        line_edges = list(map(line_to_edge, self.lines))
+        return rect_edges + line_edges

--- a/pdfplumber/container.py
+++ b/pdfplumber/container.py
@@ -1,4 +1,5 @@
 from itertools import chain
+from pdfplumber import helpers, utils
 
 def rect_to_edges(rect):
     top, bottom, left, right = [ dict(rect) for x in range(4) ]
@@ -35,6 +36,14 @@ def line_to_edge(line):
     return edge
 
 class Container(object):
+    cached_properties = [ "_rect_edges", "_edges", "_objects" ]
+
+    def flush_cache(self, properties=None):
+        props = self.cached_properties if properties == None else properties
+        for p in props:
+            if hasattr(self, p):
+                delattr(self, p)
+
     @property
     def rects(self):
         return self.objects.get("rect", [])

--- a/pdfplumber/container.py
+++ b/pdfplumber/container.py
@@ -60,10 +60,15 @@ class Container(object):
         return self.objects.get("anno", [])
 
     @property
+    def rect_edges(self):
+        if hasattr(self, "_rect_edges"): return self._edges
+        rect_edges_gen = (rect_to_edges(r) for r in self.rects)
+        self._rect_edges = list(chain(*rect_edges_gen))
+        return self._rect_edges
+
+    @property
     def edges(self):
         if hasattr(self, "_edges"): return self._edges
-        rect_edges_gen = (rect_to_edges(r) for r in self.rects)
-        rect_edges = list(chain(*rect_edges_gen))
         line_edges = list(map(line_to_edge, self.lines))
-        self._edges = rect_edges + line_edges
+        self._edges = self.rect_edges + line_edges
         return self._edges

--- a/pdfplumber/container.py
+++ b/pdfplumber/container.py
@@ -61,7 +61,9 @@ class Container(object):
 
     @property
     def edges(self):
+        if hasattr(self, "_edges"): return self._edges
         rect_edges_gen = (rect_to_edges(r) for r in self.rects)
         rect_edges = list(chain(*rect_edges_gen))
         line_edges = list(map(line_to_edge, self.lines))
-        return rect_edges + line_edges
+        self._edges = rect_edges + line_edges
+        return self._edges

--- a/pdfplumber/helpers.py
+++ b/pdfplumber/helpers.py
@@ -1,0 +1,28 @@
+import itertools
+def cluster_list(xs, tolerance=0):
+    if tolerance == 0: return [ [x] for x in sorted(xs) ]
+    if len(xs) < 2: return [ [x] for x in sorted(xs) ]
+    groups = []
+    xs = list(sorted(xs))
+    current_group = [xs[0]]
+    last = xs[0]
+    for x in xs[1:]:
+        if x <= (last + tolerance):
+            current_group.append(x)
+        else:
+            groups.append(current_group)
+            current_group = [x]
+        last = x
+    groups.append(current_group)
+    return groups
+
+def make_cluster_dict(values, tolerance):
+    clusters = cluster_list(set(values), tolerance)
+
+    nested_tuples = [ [ (val, i) for val in value_cluster ]
+        for i, value_cluster in enumerate(clusters) ]
+
+    cluster_dict = dict(itertools.chain(*nested_tuples))
+    return cluster_dict 
+
+

--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -173,17 +173,24 @@ class Page(Container):
             x_tolerance=x_tolerance,
             y_tolerance=y_tolerance)
 
-    def crop(self, bbox):
-        return CroppedPage(self, bbox)
+    def crop(self, bbox, strict=False):
+        return CroppedPage(self, bbox, strict=strict)
 
 class CroppedPage(Page):
-    def __init__(self, parent_page, bbox):
+    def __init__(self, parent_page, bbox, strict=False):
         self.parent_page = parent_page
         self.bbox = bbox
+        self.strict = strict
 
     @property
     def objects(self):
         if hasattr(self, "_objects"): return self._objects
-        self._objects = utils.within_bbox(self.parent_page.objects, self.bbox,
-            crop=True) 
+        if self.strict:
+            kwargs = { "strict": True }
+        else:
+            kwargs = { "crop": True }
+        self._objects = utils.within_bbox(
+            self.parent_page.objects,
+            self.bbox,
+            **kwargs)
         return self._objects

--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -51,8 +51,8 @@ class Page(Container):
                 attr["text"] = obj.get_text()
 
             if attr.get("y0") != None:
-                attr["top"] = self.layout.height - attr["y1"]
-                attr["bottom"] = self.layout.height - attr["y0"]
+                attr["top"] = self.height - attr["y1"]
+                attr["bottom"] = self.height - attr["y0"]
                 attr["doctop"] = self.initial_doctop + attr["top"]
 
             if objects.get(kind) == None:

--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -104,7 +104,6 @@ class Page(Container):
     def extract_table(self,
         v="lines",
         h="lines",
-        bbox=None,
         line_min_height=1,
         line_min_width=1,
         gutter_min_width=5,

--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -164,13 +164,13 @@ class Page(Container):
         return CroppedPage(self, bbox)
 
 class CroppedPage(Page):
-    def __init__(self, page, bbox):
-        self.page = page
+    def __init__(self, parent_page, bbox):
+        self.parent_page = parent_page
         self.bbox = bbox
 
     @property
     def objects(self):
         if hasattr(self, "_objects"): return self._objects
-        self._objects = utils.within_bbox(self.page.objects, self.bbox,
+        self._objects = utils.within_bbox(self.parent_page.objects, self.bbox,
             crop=True) 
         return self._objects

--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -168,6 +168,11 @@ class Page(Container):
 
         return table
 
+    def collate_chars(self, x_tolerance=0, y_tolerance=0):
+        return utils.collate_chars(self.chars,
+            x_tolerance=x_tolerance,
+            y_tolerance=y_tolerance)
+
     def crop(self, bbox):
         return CroppedPage(self, bbox)
 

--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -171,8 +171,8 @@ class Page(Container):
 
         return table
 
-    def collate_chars(self, x_tolerance=0, y_tolerance=0):
-        return utils.collate_chars(self.chars,
+    def get_text(self, x_tolerance=0, y_tolerance=0):
+        return utils.get_text(self.chars,
             x_tolerance=x_tolerance,
             y_tolerance=y_tolerance)
 

--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -113,38 +113,51 @@ class Page(Container):
         y_tolerance=0):
 
         def use_strategy(param, name):
+            # If dividers are explicitly passed
             if isinstance(param, (list, tuple)):
                 return param
-            if param in TABLE_STRATEGIES:
-                if param == "lines":
-                    if name == "v":
-                        return self.get_edge_positions("v",
-                            min_length=line_min_height,
-                            tolerance=x_tolerance)
-                    if name == "h":
-                        return self.get_edge_positions("h",
-                            min_length=line_min_width,
-                            tolerance=y_tolerance)
-                if param == "lines_strict":
-                    pass
+            else:
+                if param not in TABLE_STRATEGIES:
+                    msg = "{0} must be list/tuple of ints/floats or one of {1}"\
+                        .format(name, TABLE_STRATEGIES)
+                    raise ValueError(msg)
 
-                if param == "gutters":
-                    if name == "v":
-                        return utils.find_gutters(self.chars, "v",
-                            min_size=gutter_min_width)
-                    if name == "h":
-                        return utils.find_gutters(self.chars, "h",
-                            min_size=gutter_min_height)
+            if param == "lines":
+                if name == "v":
+                    return self.get_edge_positions("v",
+                        min_length=line_min_height,
+                        tolerance=x_tolerance)
+                if name == "h":
+                    return self.get_edge_positions("h",
+                        min_length=line_min_width,
+                        tolerance=y_tolerance)
 
-            msg = "`{0}` must be list/tuple of ints/floats or one of {1}"\
-                .format(name, TABLE_STRATEGIES)
-            raise Exception(msg)
-        
+            if param == "lines_strict":
+                if name == "v":
+                    return self.get_edge_positions("v",
+                        edge_type="line",
+                        min_length=line_min_height,
+                        tolerance=x_tolerance)
+                if name == "h":
+                    return self.get_edge_positions("h",
+                        edge_type="line",
+                        min_length=line_min_width,
+                        tolerance=y_tolerance)
+
+            if param == "gutters":
+                if name == "v":
+                    return utils.find_gutters(self.chars, "v",
+                        min_size=gutter_min_width)
+                if name == "h":
+                    return utils.find_gutters(self.chars, "h",
+                        min_size=gutter_min_height)
+
         h = use_strategy(h, "h")
         v = use_strategy(v, "v")
 
-        table = utils.extract_table(self.chars,
-            v, h, x_tolerance=x_tolerance, y_tolerance=y_tolerance)
+        table = utils.extract_table(self.chars, v, h,
+            x_tolerance=x_tolerance,
+            y_tolerance=y_tolerance)
 
         return table
 

--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -130,23 +130,11 @@ class Page(Container):
 
                 if param == "gutters":
                     if name == "v":
-                        pos = sorted(set(c["x0"] for c in self.chars))
-                        pos_gaps = ((p1, p2 - p1)
-                            for p1, p2 in zip(pos, pos[1:]))
-                        centers = [ g[0] + g[1]/2
-                            for g in pos_gaps
-                                if g[1] >= gutter_min_width ]
-                        dividers = [ pos[0] ] + centers + [ pos[-1] + 1 ]
-                        return dividers
+                        return utils.find_gutters(self.chars, "v",
+                            min_size=gutter_min_width)
                     if name == "h":
-                        pos = sorted(set(c["top"] for c in self.chars))
-                        pos_gaps = ((p1, p2 - p1)
-                            for p1, p2 in zip(pos, pos[1:]))
-                        centers = [ g[0] + g[1]/2
-                            for g in pos_gaps
-                                if g[1] >= gutter_min_height ]
-                        dividers = [ pos[0] ] + centers + [ pos[-1] + 1 ]
-                        return dividers
+                        return utils.find_gutters(self.chars, "h",
+                            min_size=gutter_min_height)
 
             msg = "`{0}` must be list/tuple of ints/floats or one of {1}"\
                 .format(name, TABLE_STRATEGIES)

--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -1,0 +1,176 @@
+from pdfplumber import utils
+from pdfplumber import helpers
+from pdfplumber.container import Container
+
+from six import string_types
+import re
+lt_pat = re.compile(r"^LT")
+
+TABLE_STRATEGIES = ("lines", "lines_strict", "gutters")
+
+class Page(Container):
+    cached_properties = Container.cached_properties + [ "_layout" ]
+
+    def __init__(self, obj, processor, initial_doctop=0):
+        self.obj = obj
+        self.processor = processor
+        self.mediabox = obj.attrs["MediaBox"]
+        self.width = self.mediabox[2] - self.mediabox[0]
+        self.height = self.mediabox[3] - self.mediabox[1]
+        self.pageid = obj.pageid
+        self.initial_doctop = initial_doctop
+
+    @property
+    def layout(self):
+        if hasattr(self, "_layout"): return self._layout
+        self._layout = self.processor(self.obj)
+        return self._layout
+
+    @property
+    def objects(self):
+        if hasattr(self, "_objects"): return self._objects
+        self._objects = self.parse_objects()
+        return self._objects
+
+    def parse_objects(self):
+        objects = {}
+
+        _round = lambda x: round(x, 3) if type(x) == float else x
+
+        def process_object(obj):
+
+            attr = dict((k, _round(v)) for k, v in obj.__dict__.items()
+                if isinstance(v, (float, int, string_types))
+                    and k[0] != "_")
+
+            kind = re.sub(lt_pat, "", obj.__class__.__name__).lower()
+            attr["object_type"] = kind
+            attr["pageid"] = self.pageid
+
+            if hasattr(obj, "get_text"):
+                attr["text"] = obj.get_text()
+
+            if attr.get("y0") != None:
+                attr["top"] = self.layout.height - attr["y1"]
+                attr["bottom"] = self.layout.height - attr["y0"]
+                attr["doctop"] = self.initial_doctop + attr["top"]
+
+            if objects.get(kind) == None:
+                objects[kind] = []
+            objects[kind].append(attr)
+
+            if hasattr(obj, "_objs"):
+                for child in obj._objs:
+                    process_object(child)
+        
+        for obj in self.layout._objs:
+            process_object(obj)
+
+        return objects
+
+    def filter_edges(self, orientation,
+        edge_type=None,
+        min_length=1):
+
+        if orientation not in ("v", "h"):
+            raise Exception("Orientation must be 'v' or 'h'")
+
+        def test(e):
+            dim = "height" if e["orientation"] == "v" else "width"
+            et = (e["object_type"] == edge_type if edge_type != None else True)
+            return et & (
+                (e["orientation"] == orientation) & 
+                (e[dim] >= min_length)
+            )
+
+        edges = filter(test, self.edges)
+        return edges
+
+    def get_edge_positions(self, orientation,
+        edge_type=None,
+        min_length=1,
+        tolerance=1):
+
+        edges = self.filter_edges(orientation,
+            edge_type=edge_type, min_length=min_length)
+
+        pos_var = "x0" if orientation == "v" else "top"
+        edges_uniq = set(e[pos_var] for e in edges)
+        edges_clust = helpers.cluster_list(edges_uniq, tolerance=tolerance)
+        edge_means = list(sorted(sum(c) / len(c) for c in edges_clust))
+
+        return edge_means
+
+    def extract_table(self,
+        v="lines",
+        h="lines",
+        bbox=None,
+        line_min_height=1,
+        line_min_width=1,
+        gutter_min_width=5,
+        gutter_min_height=5,
+        x_tolerance=0,
+        y_tolerance=0):
+
+        def use_strategy(param, name):
+            if isinstance(param, (list, tuple)):
+                return param
+            if param in TABLE_STRATEGIES:
+                if param == "lines":
+                    if name == "v":
+                        return self.get_edge_positions("v",
+                            min_length=line_min_height,
+                            tolerance=x_tolerance)
+                    if name == "h":
+                        return self.get_edge_positions("h",
+                            min_length=line_min_width,
+                            tolerance=y_tolerance)
+                if param == "lines_strict":
+                    pass
+
+                if param == "gutters":
+                    if name == "v":
+                        pos = sorted(set(c["x0"] for c in self.chars))
+                        pos_gaps = ((p1, p2 - p1)
+                            for p1, p2 in zip(pos, pos[1:]))
+                        centers = [ g[0] + g[1]/2
+                            for g in pos_gaps
+                                if g[1] >= gutter_min_width ]
+                        dividers = [ pos[0] ] + centers + [ pos[-1] + 1 ]
+                        return dividers
+                    if name == "h":
+                        pos = sorted(set(c["top"] for c in self.chars))
+                        pos_gaps = ((p1, p2 - p1)
+                            for p1, p2 in zip(pos, pos[1:]))
+                        centers = [ g[0] + g[1]/2
+                            for g in pos_gaps
+                                if g[1] >= gutter_min_height ]
+                        dividers = [ pos[0] ] + centers + [ pos[-1] + 1 ]
+                        return dividers
+
+            msg = "`{0}` must be list/tuple of ints/floats or one of {1}"\
+                .format(name, TABLE_STRATEGIES)
+            raise Exception(msg)
+        
+        h = use_strategy(h, "h")
+        v = use_strategy(v, "v")
+
+        table = utils.extract_table(self.chars,
+            v, h, x_tolerance=x_tolerance, y_tolerance=y_tolerance)
+
+        return table
+
+    def crop(self, bbox):
+        return CroppedPage(self, bbox)
+
+class CroppedPage(Page):
+    def __init__(self, page, bbox):
+        self.page = page
+        self.bbox = bbox
+
+    @property
+    def objects(self):
+        if hasattr(self, "_objects"): return self._objects
+        self._objects = utils.within_bbox(self.page.objects, self.bbox,
+            crop=True) 
+        return self._objects

--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -6,8 +6,6 @@ from six import string_types
 import re
 lt_pat = re.compile(r"^LT")
 
-TABLE_STRATEGIES = ("lines", "lines_strict", "gutters")
-
 class Page(Container):
     cached_properties = Container.cached_properties + [ "_layout" ]
 
@@ -101,6 +99,7 @@ class Page(Container):
 
         return edge_means
 
+    TABLE_STRATEGIES = ("lines", "lines_strict", "gutters")
     def extract_table(self,
         v="lines",
         h="lines",
@@ -111,15 +110,22 @@ class Page(Container):
         gutter_min_height=5,
         x_tolerance=0,
         y_tolerance=0):
+        """
+        For the purposes of this method, "lines" refers to all
+        two-dimensional lines, including "rect_edge" objects.
+
+        To use only actual "line" objects, choose the
+        "lines_strict" strategy.
+        """
 
         def use_strategy(param, name):
             # If dividers are explicitly passed
             if isinstance(param, (list, tuple)):
                 return param
             else:
-                if param not in TABLE_STRATEGIES:
+                if param not in self.TABLE_STRATEGIES:
                     msg = "{0} must be list/tuple of ints/floats or one of {1}"\
-                        .format(name, TABLE_STRATEGIES)
+                        .format(name, self.TABLE_STRATEGIES)
                     raise ValueError(msg)
 
             if param == "lines":

--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -13,10 +13,11 @@ class Page(Container):
         self.pdf = pdf
         self.page_obj = page_obj
         self.mediabox = page_obj.attrs["MediaBox"]
-        self.width = self.mediabox[2] - self.mediabox[0]
-        self.height = self.mediabox[3] - self.mediabox[1]
+        d = lambda x: utils.decimalize(x, self.pdf.precision)
+        self.width = d(self.mediabox[2] - self.mediabox[0])
+        self.height = d(self.mediabox[3] - self.mediabox[1])
         self.pageid = page_obj.pageid
-        self.initial_doctop = initial_doctop
+        self.initial_doctop = d(initial_doctop)
 
     @property
     def layout(self):
@@ -35,6 +36,9 @@ class Page(Container):
 
         d = utils.decimalize
         q = self.pdf.precision
+        h = self.height
+        idc = self.initial_doctop
+        pid = self.pageid
 
         def process_object(obj):
 
@@ -44,15 +48,15 @@ class Page(Container):
 
             kind = re.sub(lt_pat, "", obj.__class__.__name__).lower()
             attr["object_type"] = kind
-            attr["pageid"] = self.pageid
+            attr["pageid"] = pid
 
             if hasattr(obj, "get_text"):
                 attr["text"] = obj.get_text()
 
             if attr.get("y0") != None:
-                attr["top"] = self.height - attr["y1"]
-                attr["bottom"] = self.height - attr["y0"]
-                attr["doctop"] = self.initial_doctop + attr["top"]
+                attr["top"] = h - attr["y1"]
+                attr["bottom"] = h - attr["y0"]
+                attr["doctop"] = idc + attr["top"]
 
             if objects.get(kind) == None:
                 objects[kind] = []

--- a/pdfplumber/pdf.py
+++ b/pdfplumber/pdf.py
@@ -64,8 +64,8 @@ class Page(Container):
                 attr["text"] = obj.get_text()
 
             if attr.get("y0") != None:
-                attr["top"] = _round(self.layout.height - attr["y1"])
-                attr["doctop"] = _round(self.initial_doctop + attr["top"])
+                attr["top"] = self.layout.height - attr["y1"]
+                attr["doctop"] = self.initial_doctop + attr["top"]
 
             if objects.get(kind) == None:
                 objects[kind] = []

--- a/pdfplumber/pdf.py
+++ b/pdfplumber/pdf.py
@@ -8,8 +8,43 @@ from pdfminer.pdfinterp import PDFResourceManager, PDFPageInterpreter
 from pdfminer.layout import LAParams, LTChar, LTImage, LTPage
 from pdfminer.converter import PDFPageAggregator
 
+from itertools import chain
 import re
 lt_pat = re.compile(r"^LT")
+
+def rect_to_edges(rect):
+    top, bottom, left, right = [ dict(rect) for x in range(4) ]
+    top.update({
+        "object_type": "edge_top",
+        "height": 0,
+        "y0": rect["y1"],
+        "orientation": "h"
+    })
+    bottom.update({
+        "object_type": "edge_bottom",
+        "height": 0,
+        "doctop": rect["doctop"] + rect["height"],
+        "y1": rect["y0"],
+        "orientation": "h"
+    })
+    left.update({
+        "object_type": "edge_left",
+        "width": 0,
+        "x1": rect["x0"],
+        "orientation": "v"
+    })
+    right.update({
+        "object_type": "edge_right",
+        "width": 0,
+        "x0": rect["x1"],
+        "orientation": "v"
+    })
+    return [ top, bottom, left, right ]
+
+def line_to_edge(line):
+    edge = dict(line)
+    edge["is_horizontal"] = line["y0"] == line["y1"]
+    return edge
 
 class Container(object):
     @property
@@ -35,6 +70,13 @@ class Container(object):
     @property
     def annos(self):
         return self.objects.get("anno", [])
+
+    @property
+    def edges(self):
+        rect_edges_gen = (rect_to_edges(r) for r in self.rects)
+        rect_edges = list(chain(*rect_edges_gen))
+        line_edges = list(map(line_to_edge, self.lines))
+        return rect_edges + line_edges
 
 class Page(Container):
     def __init__(self, layout, initial_doctop=0):

--- a/pdfplumber/pdf.py
+++ b/pdfplumber/pdf.py
@@ -1,5 +1,6 @@
 from pdfplumber.container import Container
 from pdfplumber.page import Page
+from pdfplumber.utils import decode_text
 
 from pdfminer.pdfparser import PDFParser
 from pdfminer.pdfdocument import PDFDocument
@@ -22,6 +23,10 @@ class PDF(Container):
         self.metadata = {}
         for info in self.doc.info:
             self.metadata.update(info)
+        for k, v in self.metadata.items():
+            if hasattr(v, "resolve"):
+                v = v.resolve()
+            self.metadata[k] = decode_text(v)
         self.device = PDFPageAggregator(rsrcmgr, laparams=self.laparams)
         self.interpreter = PDFPageInterpreter(rsrcmgr, self.device)
         atexit.register(self.close)

--- a/pdfplumber/pdf.py
+++ b/pdfplumber/pdf.py
@@ -1,6 +1,8 @@
 from six import string_types
 from six.moves import cStringIO
 
+from pdfplumber.container import Container
+
 from pdfminer.pdfparser import PDFParser
 from pdfminer.pdfdocument import PDFDocument
 from pdfminer.pdfpage import PDFPage
@@ -8,75 +10,8 @@ from pdfminer.pdfinterp import PDFResourceManager, PDFPageInterpreter
 from pdfminer.layout import LAParams, LTChar, LTImage, LTPage
 from pdfminer.converter import PDFPageAggregator
 
-from itertools import chain
 import re
 lt_pat = re.compile(r"^LT")
-
-def rect_to_edges(rect):
-    top, bottom, left, right = [ dict(rect) for x in range(4) ]
-    top.update({
-        "object_type": "edge_top",
-        "height": 0,
-        "y0": rect["y1"],
-        "orientation": "h"
-    })
-    bottom.update({
-        "object_type": "edge_bottom",
-        "height": 0,
-        "doctop": rect["doctop"] + rect["height"],
-        "y1": rect["y0"],
-        "orientation": "h"
-    })
-    left.update({
-        "object_type": "edge_left",
-        "width": 0,
-        "x1": rect["x0"],
-        "orientation": "v"
-    })
-    right.update({
-        "object_type": "edge_right",
-        "width": 0,
-        "x0": rect["x1"],
-        "orientation": "v"
-    })
-    return [ top, bottom, left, right ]
-
-def line_to_edge(line):
-    edge = dict(line)
-    edge["is_horizontal"] = line["y0"] == line["y1"]
-    return edge
-
-class Container(object):
-    @property
-    def rects(self):
-        return self.objects.get("rect", [])
-
-    @property
-    def lines(self):
-        return self.objects.get("line", [])
-
-    @property
-    def images(self):
-        return self.objects.get("image", [])
-
-    @property
-    def figures(self):
-        return self.objects.get("figure", [])
-
-    @property
-    def chars(self):
-        return self.objects.get("char", [])
-
-    @property
-    def annos(self):
-        return self.objects.get("anno", [])
-
-    @property
-    def edges(self):
-        rect_edges_gen = (rect_to_edges(r) for r in self.rects)
-        rect_edges = list(chain(*rect_edges_gen))
-        line_edges = list(map(line_to_edge, self.lines))
-        return rect_edges + line_edges
 
 class Page(Container):
     def __init__(self, layout, initial_doctop=0):

--- a/pdfplumber/pdf.py
+++ b/pdfplumber/pdf.py
@@ -59,8 +59,7 @@ class Page(Container):
 import atexit
 
 class PDF(Container):
-    def __init__(self, file_or_buffer, pages=None, laparams=None):
-        self.laparams = None if laparams == None else LAParams(**laparams)
+    cached_properties = Container.cached_properties + [ "_pages" ]
 
     def __init__(self, stream, pages=None, laparams=None):
         self.laparams = None if laparams == None else LAParams(**laparams)

--- a/pdfplumber/pdf.py
+++ b/pdfplumber/pdf.py
@@ -81,8 +81,10 @@ class PDF(Container):
 
     @property
     def objects(self):
+        if hasattr(self, "_objects"): return self._objects
         all_objects = {}
         for p in self.pages:
             for kind in p.objects.keys():
                 all_objects[kind] = all_objects.get(kind, []) + p.objects[kind]
-        return all_objects
+        self._objects = all_objects
+        return self._objects

--- a/pdfplumber/pdf.py
+++ b/pdfplumber/pdf.py
@@ -19,6 +19,9 @@ class PDF(Container):
         self.pages_to_parse = pages
         rsrcmgr = PDFResourceManager()
         self.doc = PDFDocument(PDFParser(stream))
+        self.metadata = {}
+        for info in self.doc.info:
+            self.metadata.update(info)
         self.device = PDFPageAggregator(rsrcmgr, laparams=self.laparams)
         self.interpreter = PDFPageInterpreter(rsrcmgr, self.device)
         atexit.register(self.close)

--- a/pdfplumber/pdf.py
+++ b/pdfplumber/pdf.py
@@ -1,61 +1,13 @@
-from six import string_types
-from six.moves import cStringIO
-
 from pdfplumber.container import Container
+from pdfplumber.page import Page
 
 from pdfminer.pdfparser import PDFParser
 from pdfminer.pdfdocument import PDFDocument
 from pdfminer.pdfpage import PDFPage
 from pdfminer.pdfinterp import PDFResourceManager, PDFPageInterpreter
-from pdfminer.layout import LAParams, LTChar, LTImage, LTPage
+from pdfminer.layout import LAParams
 from pdfminer.converter import PDFPageAggregator
 
-import re
-lt_pat = re.compile(r"^LT")
-
-class Page(Container):
-    def __init__(self, layout, initial_doctop=0):
-        self.layout = layout
-        self.width = layout.width
-        self.height = layout.height
-        self.pageid = layout.pageid
-        self.initial_doctop = 0
-        self.objects = self.parse_objects()
-
-    def parse_objects(self):
-        objects = {}
-
-        _round = lambda x: round(x, 3) if type(x) == float else x
-
-        def process_object(obj):
-
-            attr = dict((k, _round(v)) for k, v in obj.__dict__.items()
-                if isinstance(v, (float, int, string_types))
-                    and k[0] != "_")
-
-            kind = re.sub(lt_pat, "", obj.__class__.__name__).lower()
-            attr["object_type"] = kind
-            attr["pageid"] = self.pageid
-
-            if hasattr(obj, "get_text"):
-                attr["text"] = obj.get_text()
-
-            if attr.get("y0") != None:
-                attr["top"] = self.layout.height - attr["y1"]
-                attr["doctop"] = self.initial_doctop + attr["top"]
-
-            if objects.get(kind) == None:
-                objects[kind] = []
-            objects[kind].append(attr)
-
-            if hasattr(obj, "_objs"):
-                for child in obj._objs:
-                    process_object(child)
-        
-        for obj in self.layout._objs:
-            process_object(obj)
-
-        return objects
 import atexit
 
 class PDF(Container):

--- a/pdfplumber/pdf.py
+++ b/pdfplumber/pdf.py
@@ -11,67 +11,7 @@ from pdfminer.converter import PDFPageAggregator
 import re
 lt_pat = re.compile(r"^LT")
 
-class PDF(object):
-    def __init__(self, file_or_buffer, pages=None, laparams=None):
-        self.laparams = None if laparams == None else LAParams(**laparams)
-
-        rsrcmgr = PDFResourceManager()
-        self.doc = PDFDocument(PDFParser(file_or_buffer))
-        self.device = PDFPageAggregator(rsrcmgr, laparams=self.laparams)
-        self.interpreter = PDFPageInterpreter(rsrcmgr, self.device)
-
-        self.pages = []
-
-        page_iter = (p for i, p in enumerate(PDFPage.create_pages(self.doc))
-            if pages == None or i+1 in pages)
-
-        for page in page_iter:
-            self.interpreter.process_page(page)
-            layout = self.device.get_result()
-            self.pages.append(layout)
-
-        self.objects = self.parse()
-
-    def parse(self):
-        objects = {}
-
-        def process_object(obj, page):
-            _round = lambda x: round(x, 3) if type(x) == float else x
-
-            attr = dict((k, _round(v)) for k, v in obj.__dict__.items()
-                if isinstance(v, (float, int, string_types))
-                    and k[0] != "_")
-
-            kind = re.sub(lt_pat, "", obj.__class__.__name__).lower()
-            attr["object_type"] = kind
-            attr["pageid"] = page.pageid
-
-            if hasattr(obj, "get_text"):
-                attr["text"] = obj.get_text()
-
-            if attr.get("y0") != None:
-                page_index = self.pages.index(page)
-                prev_h = sum(p.height for p in self.pages[:page_index])
-                attr["top"] = _round(page.height - attr["y1"])
-                attr["doctop"] = _round(prev_h + attr["top"])
-
-            if objects.get(kind) == None:
-                objects[kind] = []
-            objects[kind].append(attr)
-
-            if hasattr(obj, "_objs"):
-                for child in obj._objs:
-                    process_object(child, page)
-        
-        def process_page(page):
-            for child in page._objs:
-                process_object(child, page)
-
-        for page in self.pages:
-            process_page(page)
-
-        return objects
-
+class Container(object):
     @property
     def rects(self):
         return self.objects.get("rect", [])
@@ -95,3 +35,77 @@ class PDF(object):
     @property
     def annos(self):
         return self.objects.get("anno", [])
+
+class Page(Container):
+    def __init__(self, layout, initial_doctop=0):
+        self.layout = layout
+        self.width = layout.width
+        self.height = layout.height
+        self.pageid = layout.pageid
+        self.initial_doctop = 0
+        self.objects = self.parse_objects()
+
+    def parse_objects(self):
+        objects = {}
+
+        _round = lambda x: round(x, 3) if type(x) == float else x
+
+        def process_object(obj):
+
+            attr = dict((k, _round(v)) for k, v in obj.__dict__.items()
+                if isinstance(v, (float, int, string_types))
+                    and k[0] != "_")
+
+            kind = re.sub(lt_pat, "", obj.__class__.__name__).lower()
+            attr["object_type"] = kind
+            attr["pageid"] = self.pageid
+
+            if hasattr(obj, "get_text"):
+                attr["text"] = obj.get_text()
+
+            if attr.get("y0") != None:
+                attr["top"] = _round(self.layout.height - attr["y1"])
+                attr["doctop"] = _round(self.initial_doctop + attr["top"])
+
+            if objects.get(kind) == None:
+                objects[kind] = []
+            objects[kind].append(attr)
+
+            if hasattr(obj, "_objs"):
+                for child in obj._objs:
+                    process_object(child)
+        
+        for obj in self.layout._objs:
+            process_object(obj)
+
+        return objects
+
+class PDF(Container):
+    def __init__(self, file_or_buffer, pages=None, laparams=None):
+        self.laparams = None if laparams == None else LAParams(**laparams)
+
+        rsrcmgr = PDFResourceManager()
+        self.doc = PDFDocument(PDFParser(file_or_buffer))
+        self.device = PDFPageAggregator(rsrcmgr, laparams=self.laparams)
+        self.interpreter = PDFPageInterpreter(rsrcmgr, self.device)
+
+        self.pages = []
+
+        page_iter = (p for i, p in enumerate(PDFPage.create_pages(self.doc))
+            if pages == None or i+1 in pages)
+
+        doctop = 0
+        for page in page_iter:
+            self.interpreter.process_page(page)
+            layout = self.device.get_result()
+            p = Page(layout, initial_doctop=doctop)
+            self.pages.append(p)
+            doctop += p.layout.height
+
+    @property
+    def objects(self):
+        all_objects = {}
+        for p in self.pages:
+            for kind in p.objects.keys():
+                all_objects[kind] = all_objects.get(kind, []) + p.objects[kind]
+        return all_objects

--- a/pdfplumber/pdf.py
+++ b/pdfplumber/pdf.py
@@ -21,8 +21,10 @@ class PDF(object):
         self.interpreter = PDFPageInterpreter(rsrcmgr, self.device)
 
         self.pages = []
+
         page_iter = (p for i, p in enumerate(PDFPage.create_pages(self.doc))
             if pages == None or i+1 in pages)
+
         for page in page_iter:
             self.interpreter.process_page(page)
             layout = self.device.get_result()
@@ -31,13 +33,6 @@ class PDF(object):
         self.objects = self.parse()
 
     def parse(self):
-        try:
-            # pdfminer < 20131022
-            _pages = self.doc.get_pages()
-        except AttributeError:
-            # pdfminer >= 20131022
-            _pages = PDFPage.create_pages(self.doc)
-
         objects = {}
 
         def process_object(obj, page):

--- a/pdfplumber/utils.py
+++ b/pdfplumber/utils.py
@@ -64,7 +64,7 @@ def find_gutters(chars, orientation, min_size=5):
     get_end = itemgetter(end_prop)
 
     starts = list(sorted(set(map(get_start, chars))))
-    ends = list(sorted(set(map(get_end, chars))))
+    end_max = max(map(get_end, chars))
 
     start_gaps = ((p1, p2 - p1)
         for p1, p2 in zip(starts, starts[1:]))
@@ -75,8 +75,8 @@ def find_gutters(chars, orientation, min_size=5):
 
     if starts[0] < gutters[0]:
         gutters = [ starts[0] ] + gutters
-    if ends[-1] > gutters[-1]:
-        gutters = gutters + [ ends[-1] + 0.001 ]
+    if end_max > gutters[-1]:
+        gutters = gutters + [ end_max + 0.001 ]
     return gutters
 
 

--- a/pdfplumber/utils.py
+++ b/pdfplumber/utils.py
@@ -93,7 +93,7 @@ def crop_obj(obj, bbox, score=None):
         score = obj_inside_bbox_score(obj, bbox)
     if score == 0: return None
     if score == 4: return obj
-    x0, top, x1, bottom = bbox
+    x0, top, x1, bottom = map(float, bbox)
 
     copy = dict(obj)
     x_changed = False
@@ -107,7 +107,7 @@ def crop_obj(obj, bbox, score=None):
     if copy["top"] < top:
         diff = top - copy["top"]
         copy["top"] = top
-        copy["doctop"] = copy["doctop"] - diff
+        copy["doctop"] = copy["doctop"] + diff
         copy["y1"] = copy["y1"] - diff
         y_changed = True
     if copy["bottom"] > bottom:

--- a/pdfplumber/utils.py
+++ b/pdfplumber/utils.py
@@ -1,6 +1,19 @@
 from pdfplumber import helpers
 from operator import itemgetter
 import itertools
+from pdfminer.utils import PDFDocEncoding
+import six
+
+def decode_text(s):
+    """
+    Decodes a PDFDocEncoding string to Unicode.
+    Adds py3 compatability to pdfminer's version.
+    """
+    if s.startswith(b'\xfe\xff'):
+        return six.text_type(s[2:], 'utf-16be', 'ignore')
+    else:
+        ords = (ord(c) if type(c) == str else c for c in s)
+        return ''.join(PDFDocEncoding[o] for o in ords)
 
 def is_dataframe(collection):
     cls = collection.__class__

--- a/pdfplumber/utils.py
+++ b/pdfplumber/utils.py
@@ -23,11 +23,12 @@ def collate_line(line_chars, tolerance=0):
         coll += char["text"]
     return coll
 
-get_0 = itemgetter(0)
-get_1 = itemgetter(1)
 def collate_chars(chars, x_tolerance=0, y_tolerance=0):
     if len(chars) == 0:
         raise Exception("List of chars is empty.")
+
+    get_0 = itemgetter(0)
+    get_1 = itemgetter(1)
 
     chars = to_list(chars)
 
@@ -45,25 +46,30 @@ def collate_chars(chars, x_tolerance=0, y_tolerance=0):
     return coll
 
 
-def find_gutters(chars, orientation, min_size=5, include_outer=True):
+def find_gutters(chars, orientation, min_size=5):
     if orientation not in ("h", "v"):
         raise ValueError('`orientation` must be "h" or "v".')
 
-    prop = "x0" if orientation == "v" else "top"
+    start_prop = "x0" if orientation == "v" else "top"
+    end_prop = "x1" if orientation == "v" else "bottom"
 
-    pos = sorted(set(c[prop] for c in chars))
+    get_start = itemgetter(start_prop)
+    get_end = itemgetter(end_prop)
 
-    pos_gaps = ((p1, p2 - p1)
-        for p1, p2 in zip(pos, pos[1:]))
+    starts = list(sorted(set(map(get_start, chars))))
+    ends = list(sorted(set(map(get_end, chars))))
 
-    centers = [ g[0] + g[1]/2
-        for g in pos_gaps
+    start_gaps = ((p1, p2 - p1)
+        for p1, p2 in zip(starts, starts[1:]))
+
+    gutters = [ g[0] + g[1]/2
+        for g in start_gaps
             if g[1] >= min_size ]
 
-    if include_outer:
-        gutters = [ pos[0] ] + centers + [ pos[-1] + 1 ]
-    else:
-        gutters = centers
+    if starts[0] < gutters[0]:
+        gutters = [ starts[0] ] + gutters
+    if ends[-1] > gutters[-1]:
+        gutters = gutters + [ ends[-1] + 0.001 ]
     return gutters
 
 

--- a/pdfplumber/utils.py
+++ b/pdfplumber/utils.py
@@ -1,7 +1,6 @@
 from pdfplumber import helpers
 from operator import itemgetter
 import itertools
-import pandas as pd
 
 def is_dataframe(collection):
     cls = collection.__class__
@@ -13,9 +12,6 @@ def to_list(collection):
         return collection.to_dict("records")
     else:
         return collection
-
-def to_dataframe(thing):
-    return pd.DataFrame(thing)
 
 def collate_line(line_chars, tolerance=0):
     coll = ""
@@ -132,9 +128,8 @@ def within_bbox(objs, bbox, strict=True, crop=False):
         return dict((k, within_bbox(v, bbox, strict=strict, crop=crop))
             for k,v in objs.items())
 
-    using_pandas = isinstance(objs, pd.DataFrame)
-    if using_pandas:
-        objs = objs.to_dict("records")
+    initial_type = type(objs)
+    objs = to_list(objs)
 
     scores = ((obj, obj_inside_bbox_score(obj, bbox)) for obj in objs)
 
@@ -146,10 +141,7 @@ def within_bbox(objs, bbox, strict=True, crop=False):
     else:
         matching = [ s[0] for s in scores if s[1] > 0 ]
     
-    if using_pandas:
-        return pd.DataFrame(matching)
-    else:
-        return matching
+    return initial_type(matching)
 
 def dividers_to_bounds(dividers):
     return list(zip(dividers, dividers[1:]))
@@ -160,7 +152,7 @@ def extract_table(chars,
     x_tolerance=0,
     y_tolerance=0):
 
-    using_pandas = is_dataframe(chars)
+    initial_type = type(chars)
     chars = to_list(chars)
 
     v_bounds = dividers_to_bounds(v_dividers)
@@ -183,7 +175,4 @@ def extract_table(chars,
             row_arr.append(cell_value)
         table_arr.append(row_arr)
 
-    if using_pandas:
-        return pd.DataFrame(table_arr)
-    else:
-        return table_arr
+    return initial_type(table_arr)

--- a/pdfplumber/utils.py
+++ b/pdfplumber/utils.py
@@ -47,8 +47,15 @@ def collate_chars(chars, x_tolerance=0, y_tolerance=0):
 
 
 def find_gutters(chars, orientation, min_size=5):
+    """
+    The size of a gutter is the distance between the beginning
+    of the current character and the beginning of the next character.
+    """
     if orientation not in ("h", "v"):
         raise ValueError('`orientation` must be "h" or "v".')
+
+    if len(chars) == 0:
+        raise ValueError("No chars.")
 
     start_prop = "x0" if orientation == "v" else "top"
     end_prop = "x1" if orientation == "v" else "bottom"

--- a/pdfplumber/utils.py
+++ b/pdfplumber/utils.py
@@ -1,37 +1,5 @@
 import pandas as pd
-import itertools
-
-def compatible_iter(thing):
-    if hasattr(thing, "iterrows"):
-        return thing.iterrows()
-    else:
-        return enumerate(thing)
-
-def cluster_list(xs, tolerance=0):
-    if tolerance == 0: return [ [x] for x in sorted(xs) ]
-    if len(xs) < 2: return [ [x] for x in sorted(xs) ]
-    groups = []
-    xs = list(sorted(xs))
-    current_group = [xs[0]]
-    last = xs[0]
-    for x in xs[1:]:
-        if x <= (last + tolerance):
-            current_group.append(x)
-        else:
-            groups.append(current_group)
-            current_group = [x]
-        last = x
-    groups.append(current_group)
-    return groups
-
-def make_cluster_dict(values, tolerance):
-    clusters = cluster_list(set(values), tolerance)
-
-    nested_tuples = [ [ (val, i) for val in value_cluster ]
-        for i, value_cluster in enumerate(clusters) ]
-
-    cluster_dict = dict(itertools.chain(*nested_tuples))
-    return cluster_dict 
+from pdfplumber import helpers
 
 def collate_chars(chars, x_tolerance=0, y_tolerance=0):
     using_pandas = isinstance(chars, pd.DataFrame)
@@ -50,7 +18,7 @@ def collate_chars(chars, x_tolerance=0, y_tolerance=0):
             coll += char["text"]
         return coll
 
-    doctop_clusters = make_cluster_dict(_chars["doctop"], y_tolerance)
+    doctop_clusters = helpers.make_cluster_dict(_chars["doctop"], y_tolerance)
     _chars["doctop_cluster"] = _chars["doctop"].apply(doctop_clusters.get)
     dc_grp = _chars.sort_values("doctop_cluster").groupby("doctop_cluster")
     coll = "\n".join(dc_grp.apply(collate_line))
@@ -114,7 +82,7 @@ def extract_columns(chars,
 
     collator = lambda x: collate_chars(x, x_tolerance=x_tolerance, y_tolerance=y_tolerance)
 
-    doctop_clusters = make_cluster_dict(_chars["doctop"], y_tolerance)
+    doctop_clusters = helpers.make_cluster_dict(_chars["doctop"], y_tolerance)
     _chars["doctop_cluster"] = _chars["doctop"].apply(doctop_clusters.get)
 
     collated = _chars.groupby([ "doctop_cluster", "column" ])\

--- a/pdfplumber/utils.py
+++ b/pdfplumber/utils.py
@@ -146,17 +146,15 @@ def within_bbox(objs, bbox, strict=True, crop=False):
 def dividers_to_bounds(dividers):
     return list(zip(dividers, dividers[1:]))
 
-def extract_table(chars,
-    v_dividers=None,
-    h_dividers=None,
+def extract_table(chars, v, h,
     x_tolerance=0,
     y_tolerance=0):
 
     initial_type = type(chars)
     chars = to_list(chars)
 
-    v_bounds = dividers_to_bounds(v_dividers)
-    h_bounds = dividers_to_bounds(h_dividers)
+    v_bounds = dividers_to_bounds(v)
+    h_bounds = dividers_to_bounds(h)
 
     table_arr = []
     for hb in h_bounds:

--- a/pdfplumber/utils.py
+++ b/pdfplumber/utils.py
@@ -30,9 +30,10 @@ def collate_line(line_chars, tolerance=0):
 get_0 = itemgetter(0)
 get_1 = itemgetter(1)
 def collate_chars(chars, x_tolerance=0, y_tolerance=0):
-    chars = to_list(chars)
     if len(chars) == 0:
         raise Exception("List of chars is empty.")
+
+    chars = to_list(chars)
 
     doctops = map(itemgetter("doctop"), chars)
 
@@ -48,6 +49,7 @@ def collate_chars(chars, x_tolerance=0, y_tolerance=0):
 
     coll = "\n".join(lines)
     return coll
+
 
 def find_gutters(chars, orientation, min_size=5, include_outer=True):
     if orientation not in ("h", "v"):
@@ -158,27 +160,24 @@ def extract_table(chars,
     x_tolerance=0,
     y_tolerance=0):
 
-    using_pandas = isinstance(chars, pd.DataFrame)
-    if not using_pandas:
-        chars = pd.DataFrame(chars)
+    using_pandas = is_dataframe(chars)
+    chars = to_list(chars)
 
     v_bounds = dividers_to_bounds(v_dividers)
     h_bounds = dividers_to_bounds(h_dividers)
 
     table_arr = []
     for hb in h_bounds:
-        row = chars[
-            (chars["top"] >= hb[0]) &
-            (chars["top"] < hb[1])
-        ]
+        test = lambda c: (c["top"] >= hb[0]) & (c["top"] < hb[1])
+        row = list(filter(test, chars))
         row_arr = []
         for vb in v_bounds:
-            cell = row[
-                (row["x0"] >= vb[0]) &
-                (row["x0"] < vb[1])
-            ]
+            test = lambda c: (c["x0"] >= vb[0]) & (c["x0"] < vb[1])
+            cell = list(filter(test, row))
             if len(cell):
-                cell_value = collate_chars(cell, x_tolerance=x_tolerance, y_tolerance=y_tolerance).strip()
+                cell_value = collate_chars(cell,
+                    x_tolerance=x_tolerance,
+                    y_tolerance=y_tolerance).strip()
             else:
                 cell_value = None
             row_arr.append(cell_value)

--- a/pdfplumber/utils.py
+++ b/pdfplumber/utils.py
@@ -32,14 +32,12 @@ def collate_chars(chars, x_tolerance=0, y_tolerance=0):
     chars = to_list(chars)
 
     doctops = map(itemgetter("doctop"), chars)
-
     doctop_clusters = helpers.make_cluster_dict(doctops, y_tolerance)
 
     with_cluster = ((char, doctop_clusters.get(char["doctop"]))
         for char in chars)
 
     groups = itertools.groupby(sorted(with_cluster, key=get_1), key=get_1)
-
     lines = (collate_line(map(get_0, items), x_tolerance)
         for k, items in groups)
 

--- a/pdfplumber/utils.py
+++ b/pdfplumber/utils.py
@@ -47,7 +47,7 @@ def collate_line(line_chars, tolerance=0):
         coll += char["text"]
     return coll
 
-def collate_chars(chars, x_tolerance=0, y_tolerance=0):
+def get_text(chars, x_tolerance=0, y_tolerance=0):
     if len(chars) == 0:
         raise Exception("List of chars is empty.")
 
@@ -69,6 +69,7 @@ def collate_chars(chars, x_tolerance=0, y_tolerance=0):
     coll = "\n".join(lines)
     return coll
 
+collate_chars = get_text
 
 def find_gutters(chars, orientation, min_size=5):
     """

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ import subprocess
 base_reqs = [
     "chardet",
     "pycrypto",
-    "pandas>=0.17.1",
     "pdfminer.six>=20151013"
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ import subprocess
 base_reqs = [
     "chardet",
     "pycrypto",
+    "unicodecsv>=0.14.1",
     "pdfminer.six>=20151013"
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,8 @@ import sys, os
 from setuptools import setup, find_packages
 import subprocess
 
+version = __import__("pdfplumber").VERSION
+
 base_reqs = [
     "chardet",
     "pycrypto",
@@ -11,8 +13,8 @@ base_reqs = [
 
 setup(
     name="pdfplumber",
-    description="Plumb a PDF for detailed information about each char, rectangle, line, etc.",
-    version="0.2.0",
+    description="Plumb a PDF for detailed information about each char, rectangle, and line — and easily extract text and tables.",
+    version=version,
     packages=find_packages(exclude=["test",]),
     tests_require=[ "nose", "pandas" ] + base_reqs,
     install_requires=base_reqs,

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     description="Plumb a PDF for detailed information about each char, rectangle, line, etc.",
     version="0.2.0",
     packages=find_packages(exclude=["test",]),
-    tests_require=[ "nose" ] + base_reqs,
+    tests_require=[ "nose", "pandas" ] + base_reqs,
     install_requires=base_reqs,
     entry_points={
         "console_scripts": [ "pdfplumber = pdfplumber.cli:main" ] 

--- a/tests/test-basics.py
+++ b/tests/test-basics.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+import unittest
+import pandas as pd
+import pdfplumber
+import sys, os
+import six
+
+import logging
+logging.disable(logging.ERROR)
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+
+class Test(unittest.TestCase):
+
+    def setUp(self):
+        path = os.path.join(HERE, "pdfs/nics-background-checks-2015-11.pdf")
+        self.pdf = pdfplumber.from_path(path)
+
+    def test_metadata(self):
+        metadata = self.pdf.metadata
+        assert(isinstance(metadata["Producer"], six.text_type))
+
+    def test_pagecount(self):
+        assert(len(self.pdf.pages) == 1)

--- a/tests/test-la-precinct-bulletin-2014-p1.py
+++ b/tests/test-la-precinct-bulletin-2014-p1.py
@@ -109,9 +109,6 @@ class Test(unittest.TestCase):
         self.pdf = pdfplumber.from_path(path)
         self.PDF_WIDTH = self.pdf.pages[0].width
 
-    def test_plain(self):
-        pass
-
     def test_pandas(self):
         p1 = PrecinctPage(self.pdf.pages[0]).to_dict()
         assert(p1["registered_voters"] == 1100)

--- a/tests/test-la-precinct-bulletin-2014-p1.py
+++ b/tests/test-la-precinct-bulletin-2014-p1.py
@@ -2,7 +2,7 @@
 import unittest
 import pandas as pd
 import pdfplumber
-from pdfplumber.utils import within_bbox, extract_columns, collate_chars
+from pdfplumber.utils import within_bbox, collate_chars
 import sys, os
 import re
 

--- a/tests/test-la-precinct-bulletin-2014-p1.py
+++ b/tests/test-la-precinct-bulletin-2014-p1.py
@@ -24,12 +24,10 @@ def parse_results_line(chars):
     return { "text": left, "aff": mid, "votes": right }
 
 class PrecinctPage(object):
-    def __init__(self, pdf, pageid):
-        z = lambda objs: pd.DataFrame([ x
-            for x in objs if x["pageid"] == pageid])
-        self.chars = z(pdf.chars)
-        self.lines = z(pdf.lines)
-        self.rects = z(pdf.rects)
+    def __init__(self, page):
+        self.chars = pd.DataFrame(page.chars)
+        self.lines = pd.DataFrame(page.lines)
+        self.rects = pd.DataFrame(page.rects)
         self.bboxes = self.get_bboxes()
     
     def get_bboxes(self):
@@ -115,7 +113,7 @@ class Test(unittest.TestCase):
         pass
 
     def test_pandas(self):
-        p1 = PrecinctPage(self.pdf, 1).to_dict()
+        p1 = PrecinctPage(self.pdf.pages[0]).to_dict()
         assert(p1["registered_voters"] == 1100)
         assert(p1["ballots_cast"] == 327)
         assert(p1["precinct"] == "0050003A|ACTON")

--- a/tests/test-nics-background-checks-2015-11.py
+++ b/tests/test-nics-background-checks-2015-11.py
@@ -67,7 +67,7 @@ class Test(unittest.TestCase):
             colsum = sum(row[c] or 0 for row in parsed_table)
             assert(colsum == (total * 2))
 
-        month_chars = within_bbox(chars, (0, 35, self.PDF_WIDTH, 60))
+        month_chars = within_bbox(chars, (0, 35, self.PDF_WIDTH, 65))
         month_text = collate_chars(month_chars, x_tolerance=2)
         assert(month_text == "November - 2015")
 
@@ -89,6 +89,6 @@ class Test(unittest.TestCase):
             colsum = table[c].sum()
             assert(colsum == (total * 2))
 
-        month_chars = within_bbox(chars, (0, 35, self.PDF_WIDTH, 60))
+        month_chars = within_bbox(chars, (0, 35, self.PDF_WIDTH, 65))
         month_text = collate_chars(month_chars, x_tolerance=2)
         assert(month_text == "November - 2015")

--- a/tests/test-nics-background-checks-2015-11.py
+++ b/tests/test-nics-background-checks-2015-11.py
@@ -2,7 +2,7 @@
 import unittest
 import pandas as pd
 import pdfplumber
-from pdfplumber.utils import within_bbox, extract_columns, collate_chars
+from pdfplumber.utils import within_bbox, collate_chars
 import sys, os
 
 import logging
@@ -46,18 +46,21 @@ class Test(unittest.TestCase):
         self.PDF_WIDTH = self.pdf.pages[0].width
 
     def test_plain(self):
-        chars = self.pdf.chars
-        table_chars = within_bbox(chars, (0, 77, self.PDF_WIDTH, 485))
-        table = extract_columns(table_chars, x_tolerance=2)
+        page = self.pdf.pages[0]
+        cropped = page.crop((0, 80, self.PDF_WIDTH, 485))
+        table = cropped.extract_table(h="gutters",
+            x_tolerance=5,
+            y_tolerance=5,
+            gutter_min_height=5)
 
         def parse_value(k, x):
             if k == 0: return x
-            if x == "": return None
+            if x == None: return None
             return int(x.replace(",", ""))
 
         def parse_row(row):
-            return dict((COLUMNS[k], parse_value(k, v))
-                for k, v in row.items())
+            return dict((COLUMNS[i], parse_value(i, v))
+                for i, v in enumerate(row))
 
         parsed_table = [ parse_row(row) for row in table ]
 
@@ -67,14 +70,20 @@ class Test(unittest.TestCase):
             colsum = sum(row[c] or 0 for row in parsed_table)
             assert(colsum == (total * 2))
 
-        month_chars = within_bbox(chars, (0, 35, self.PDF_WIDTH, 65))
+        month_chars = within_bbox(page.chars, (0, 35, self.PDF_WIDTH, 65))
         month_text = collate_chars(month_chars, x_tolerance=2)
         assert(month_text == "November - 2015")
 
     def test_pandas(self):
-        chars = pd.DataFrame(self.pdf.chars)
-        table_chars = within_bbox(chars, (0, 77, self.PDF_WIDTH, 485))
-        table = extract_columns(table_chars, x_tolerance=2)
+        page = self.pdf.pages[0]
+        cropped = page.crop((0, 80, self.PDF_WIDTH, 485))
+
+        _table = cropped.extract_table(h="gutters",
+            x_tolerance=5,
+            y_tolerance=5,
+            gutter_min_height=5)
+        
+        table = pd.DataFrame(_table)
 
         def parse_value(x):
             if pd.isnull(x): return None
@@ -89,6 +98,6 @@ class Test(unittest.TestCase):
             colsum = table[c].sum()
             assert(colsum == (total * 2))
 
-        month_chars = within_bbox(chars, (0, 35, self.PDF_WIDTH, 65))
+        month_chars = within_bbox(page.chars, (0, 35, self.PDF_WIDTH, 65))
         month_text = collate_chars(month_chars, x_tolerance=2)
         assert(month_text == "November - 2015")


### PR DESCRIPTION
A *ton* of improvements and new features:

- Shifts to a lazy-loading paradigm, so that you don't have to process an entire PDF just to access one page.
- Strips out `pandas` requirement and usage.
  - Results in a 3x-ish speedup for `within_bbox` and similar methods, thanks to short-circuiting `&` operators.
- Moves from `float`s to `Decimal`s to improve accuracy of equality comparisons.
- Moves to a more modular architecture, adds `Container`, `Page`, and `CroppedPage` classes.
- Adds `Page.crop(...)`.
- Adds `Page.extract_table(...)` for Tabula-like functionality.
- Adds `PDF.metadata` property.
- Adds derived properties `Container.rect_edges` and `Container.edges`, decomposing each rectangle decomposed into its constituent lines.
- Renames `collate_chars(...)` to `get_text(...)` (while retaining a reference to the former).
- Enriches the the command-line tool's JSON output to include PDF metadata and page dimensions. [https://github.com/jsvine/pdfplumber/issues/3]