### PR TITLE
decimalize page height-it seems to sometimes come as a float

### DIFF
--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -62,8 +62,8 @@ class Page(Container):
                 attr["text"] = obj.get_text()
 
             if attr.get("y0") != None:
-                attr["top"] = h - attr["y1"]
-                attr["bottom"] = h - attr["y0"]
+                attr["top"] = d(h) - attr["y1"]
+                attr["bottom"] = d(h) - attr["y0"]
                 attr["doctop"] = idc + attr["top"]
 
             if objects.get(kind) == None:


### PR DESCRIPTION
See: https://github.com/jsvine/pdfplumber/issues/21 . Not sure this is the best fix, but seems to work for me. 