### PR TITLE
v0.5.3; quickfix re. ImageMagick/wand import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. Currently g
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [0.5.3] — 2017-02-27
+### Fixed
+- Allow `pdfplumber` import even if ImageMagick not installed.
+
 ## [0.5.2] — 2017-02-27
 ### Added
 - Access to `curve` points. (E.g., `page.curves[0]["points"]`.)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PDFPlumber `v0.5.2`
+# PDFPlumber `v0.5.3`
 
 Plumb a PDF for detailed information about each text character, rectangle, and line. Plus: Table extraction and visual debugging.
 
@@ -21,6 +21,8 @@ Currently [tested](tests/) on [Python 2.7, 3.1, 3.4, 3.5, and 3.6](tox.ini).
 ```sh
 pip install pdfplumber
 ```
+
+To use `pdfplumber`'s visual-debugging tools, you'll also need to have [`ImageMagick`](https://www.imagemagick.org/) installed on your computer. [Installation instructions here](http://docs.wand-py.org/en/latest/guide/install.html#install-imagemagick-debian).
 
 ## Command line interface
 

--- a/pdfplumber/_version.py
+++ b/pdfplumber/_version.py
@@ -1,2 +1,2 @@
-version_info = (0, 5, 2)
+version_info = (0, 5, 3)
 __version__ = '.'.join(map(str, version_info))

--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -1,7 +1,6 @@
 from . import utils
 from .table import TableFinder
 from .container import Container
-from .display import PageImage, DEFAULT_RESOLUTION
 from copy import copy
 
 from six import string_types
@@ -204,11 +203,13 @@ class Page(Container):
         filtered.bbox = self.bbox
         return filtered
 
-    def to_image(self, resolution=DEFAULT_RESOLUTION):
+    def to_image(self, resolution=None):
         """
         For conversion_kwargs, see http://docs.wand-py.org/en/latest/wand/image.html#wand.image.Image
         """
-        return PageImage(self, resolution=resolution)
+        from .display import PageImage, DEFAULT_RESOLUTION
+        res = resolution or DEFAULT_RESOLUTION
+        return PageImage(self, resolution=res)
 
 class DerivedPage(Page):
     is_original = False


### PR DESCRIPTION
Allow `pdfplumber` import even if ImageMagick not installed.