### PR TITLE
Update setup.py so it doesn't fail on pip install pycrypto

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(os.path.join(HERE, NAME, '_version.py')) as f:
 
 base_reqs = [
     "chardet",
-    "pycrypto",
+    "pycryptodome",
     "unicodecsv>=0.14.1",
     "pdfminer.six==20151013",
     "pillow>=3.0.0",


### PR DESCRIPTION
replaced pycrypto with pycryptodome dependency so install doesn't fail on pip install