### PR TITLE
reset wand alpha_channel to backgound white

### DIFF
--- a/pdfplumber/display.py
+++ b/pdfplumber/display.py
@@ -23,6 +23,9 @@ def get_page_image(pdf_path, page_no, resolution):
     """
     page_path = "{0}[{1}]".format(pdf_path, page_no)
     with wand.image.Image(filename=page_path, resolution=resolution) as img:
+        if img.alpha_channel:
+            img.background_color = wand.image.Color('white')
+            img.alpha_channel = 'background'
         with img.convert("png") as png:
             im = PIL.Image.open(BytesIO(png.make_blob()))
             if "transparency" in im.info:


### PR DESCRIPTION
in some cases, wand image alpha channel could make the whole page black out. -_-||

- raw pdf:
[background_alpha_channel.pdf](https://github.com/jsvine/pdfplumber/files/2204779/background_alpha_channel.pdf)

-converted image w/o background white out
![background_alpha_channel](https://user-images.githubusercontent.com/1425792/42866006-f1bf843a-8a9d-11e8-98d6-6a59993d79fd.png)

- converted image w/ background white out
![whiteout_background](https://user-images.githubusercontent.com/1425792/42866075-1e0dac1a-8a9e-11e8-950f-4b28649c706e.png)
