### PR TITLE
resolve page rotation when PDFObjRef is returned

### DIFF
--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -16,7 +16,10 @@ class Page(Container):
         self.pdf = pdf
         self.page_obj = page_obj
         self.page_number = page_number
-        self.rotation = self.page_obj.attrs.get("Rotate", 0) % 360
+        _rotation = self.page_obj.attrs.get("Rotate", 0)
+        if not isinstance(_rotation, int):
+            _rotation = _rotation.resolve()
+        self.rotation = _rotation % 360
         self.page_obj.rotate = self.rotation
         self.initial_doctop = self.decimalize(initial_doctop)
 


### PR DESCRIPTION
pdfplumber ERROR message without the fix.
```
>>> pdf = pdfplumber.open(fpath)
>>> page_num = len(pdf.pages)
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "~/.pyenv/versions/3.5.2/lib/python3.5/site-packages/pdfplumber/pdf.py", line 58, in pages
    p = Page(self, page, page_number=page_number, initial_doctop=doctop)
  File "~/.pyenv/versions/3.5.2/lib/python3.5/site-packages/pdfplumber/page.py", line 19, in __init__
    self.rotation = self.page_obj.attrs.get("Rotate", 0) % 360
TypeError: unsupported operand type(s) for %: 'PDFObjRef' and 'int'
```