### PR TITLE
Make whitespace checking more robust

### DIFF
--- a/pdfplumber/utils.py
+++ b/pdfplumber/utils.py
@@ -163,7 +163,7 @@ def extract_words(chars,
         current_word = []
 
         for char in chars_sorted:
-            if not keep_blank_chars and get_text(char) == " ":
+            if not keep_blank_chars and get_text(char).isspace():
                 if len(current_word) > 0:
                     words.append(current_word)
                     current_word = []


### PR DESCRIPTION
Currently only looks for the literal " " and fails on other whitespace characters like "\xa0" (non-breaking space). This causes `extract_words()` to not split words on these characters, and also to pick up stray whitespace as words. Python's builtin string method `isspace()` is perfect for this.

I've never actually written a test before but from looking at some of yours, this might do the trick. I've attached an example document below. Currently `len(words) == 32` but from looking at the document you can see it should be 25, and indeed it is when using `isspace()`.

```python
import pdfplumber
filename = "whitespace_test.pdf"
with pdfplumber.open(filename) as pdf:
    first_page = pdf.pages[0]
    words = first_page.extract_words()
    assert(len(words) == 25)
```
[whitespace_test.pdf](https://github.com/jsvine/pdfplumber/files/2497638/whitespace_test.pdf)
