### PR TITLE
Option to return the matrix and bounding boxes of objects

### DIFF
--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -27,6 +27,8 @@ class Page(Container):
         self.cropbox = self.decimalize(resolve_all(cropbox)) if cropbox is not None else None
         self.mediabox = self.decimalize(resolve_all(mediabox) or self.cropbox)
         m = self.mediabox
+        self.return_matrix = False
+        self.return_bbox = False
 
         if self.rotation in [ 90, 270 ]:
             self.bbox = self.decimalize((
@@ -92,6 +94,14 @@ class Page(Container):
             "imagemask",
             "pts",
         ]
+
+        # Optionally return or ignore bbox
+        if not self.return_bbox:
+            IGNORE.append("bbox")
+
+        # Optionally return or ignore matrix
+        if not self.return_matrix:
+            IGNORE.append("matrix")
 
         noop = lambda x: x
         str_conv = lambda x: str(x or "")

--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -82,8 +82,6 @@ class Page(Container):
             )
 
         IGNORE = [
-            "bbox",
-            "matrix",
             "_text",
             "_objs",
             "groups",
@@ -133,6 +131,8 @@ class Page(Container):
             "stream": noop,
             "stroke": noop,
             "stroking_color": noop,
+            "bbox": noop,
+            "matrix": noop,
         }
 
         def process_object(obj):

--- a/pdfplumber/utils.py
+++ b/pdfplumber/utils.py
@@ -99,7 +99,10 @@ def _decimalize(v, q = None):
 
     # Resolve PDFOBjRef objects
     elif isinstance(v, PDFObjRef):
-        return decimalize(resolve1(v))
+        if resolve1(v):
+            return decimalize(resolve1(v))
+        else:
+            return decimalize(0)
 
     # Convert float-like
     elif isinstance(v, numbers.Real):

--- a/pdfplumber/utils.py
+++ b/pdfplumber/utils.py
@@ -1,5 +1,6 @@
 from pdfminer.utils import PDFDocEncoding
 from pdfminer.psparser import PSLiteral
+from pdfminer.pdftypes import PDFObjRef, resolve1 
 from decimal import Decimal, ROUND_HALF_UP
 import numbers
 from operator import itemgetter
@@ -95,6 +96,10 @@ def _decimalize(v, q = None):
     # Convert int-like
     elif isinstance(v, numbers.Integral):
         return Decimal(int(v))
+
+    # Resolve PDFOBjRef objects
+    elif isinstance(v, PDFObjRef):
+        return decimalize(resolve1(v))
 
     # Convert float-like
     elif isinstance(v, numbers.Real):


### PR DESCRIPTION
The translation matrix and bbox of objects on a page are ignored when parsed. This change adds an option to return the matrices and bounding boxes of the objects. By default they are still ignored. 