### PR TITLE
sort by y coordinate

### DIFF
--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -176,7 +176,8 @@ class Page(Container):
 
     def extract_tables(self, table_settings={}):
         tables = self.find_tables(table_settings)
-        return [ table.extract() for table in tables ]
+        tables = sorted(tables, key=lambda x: x.bbox[1])
+        return [ table.extract() for table in tables]
 
     def extract_table(self, table_settings={}):
         tables = self.find_tables(table_settings)


### PR DESCRIPTION
sort tables by bbox[1] (y coordinate), this will make us extracting tables orderly.
As before, we sometimes got tables by func extract_tables with wrong order.For example,
if a table separated into 2 or more parts in different pages, the tables we extract will be sorted
by length desc, in this way we can not extract them in their raw order .So i think we should extract
then by y coordinate ,that is the right way to avoid confused order after extracting