### PR TITLE
added optional support for cdecimal to improve performance

### DIFF
--- a/pdfplumber/cli.py
+++ b/pdfplumber/cli.py
@@ -2,7 +2,10 @@
 import pdfplumber
 import argparse
 from itertools import chain
-from decimal import Decimal, ROUND_HALF_UP
+try:
+    from cdecimal import Decimal, ROUND_HALF_UP
+except ImportError:
+    from decimal import Decimal, ROUND_HALF_UP
 import unicodecsv
 import codecs
 import json

--- a/pdfplumber/utils.py
+++ b/pdfplumber/utils.py
@@ -1,6 +1,9 @@
 from pdfminer.utils import PDFDocEncoding
 from pdfminer.psparser import PSLiteral
-from decimal import Decimal, ROUND_HALF_UP
+try:
+    from cdecimal import Decimal, ROUND_HALF_UP
+except ImportError:
+    from decimal import Decimal, ROUND_HALF_UP
 import numbers
 from operator import itemgetter
 import itertools


### PR DESCRIPTION
`cdecimal` is much faster than `decimal` in Python 2 (it was later integrated into Python 3).
This pull request lets pdfplumber import `cdecimal` if it exists.