### PR TITLE
Fix unused  argument keep_blank_chars in page.extract_words

### DIFF
--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -200,7 +200,8 @@ class Page(Container):
 
         return utils.extract_words(self.chars,
             x_tolerance=x_tolerance,
-            y_tolerance=y_tolerance)
+            y_tolerance=y_tolerance,
+            keep_blank_chars=keep_blank_chars)
 
     def crop(self, bbox):
         class CroppedPage(DerivedPage):


### PR DESCRIPTION
Make [page.extract_words](https://github.com/jsvine/pdfplumber/blob/master/pdfplumber/page.py#L196) pass down its `keep_blank_chars` argument to [utils.extract_words](https://github.com/jsvine/pdfplumber/blob/master/pdfplumber/utils.py#L167).