### PR TITLE
add resolve_all to page rotation attr

### DIFF
--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -16,7 +16,7 @@ class Page(Container):
         self.pdf = pdf
         self.page_obj = page_obj
         self.page_number = page_number
-        _rotation = self.decimalize(self.page_obj.attrs.get("Rotate", 0))
+        _rotation = self.decimalize(resolve_all(self.page_obj.attrs.get("Rotate", 0)))
         self.rotation =  _rotation % 360
         self.page_obj.rotate = self.rotation
         self.initial_doctop = self.decimalize(initial_doctop)


### PR DESCRIPTION
[rotation.pdf](https://github.com/jsvine/pdfplumber/files/3532573/rotation.pdf)
```
p = Page(self, page, page_number=page_number, initial_doctop=doctop)
  File "venv/lib/python3.7/site-packages/pdfplumber/page.py", line 22, in __init__
    _rotation = self.decimalize(self.page_obj.attrs.get("Rotate", 0))
  File "venv/lib/python3.7/site-packages/pdfplumber/page.py", line 50, in decimalize
    return utils.decimalize(x, self.pdf.precision)
  File "venv/lib/python3.7/site-packages/pdfplumber/utils.py", line 117, in decimalize
    return _decimalize(v, q)
  File "venv/lib/python3.7/site-packages/pdfplumber/utils.py", line 110, in _decimalize
    raise ValueError("Cannot convert {0} to Decimal.".format(v))
ValueError: Cannot convert <PDFObjRef:8> to Decimal.
```