### PR TITLE
Fix #124 opening PDF with bytes stream

### DIFF
--- a/pdfplumber/display.py
+++ b/pdfplumber/display.py
@@ -17,12 +17,13 @@ DEFAULT_STROKE = COLORS.RED + (200,)
 DEFAULT_STROKE_WIDTH = 1
 DEFAULT_RESOLUTION = 72
 
-def get_page_image(pdf_path, page_no, resolution):
+def get_page_image(stream, page_no, resolution):
     """
     For kwargs, see http://docs.wand-py.org/en/latest/wand/image.html#wand.image.Image
     """
-    page_path = "{0}[{1}]".format(pdf_path, page_no)
-    with wand.image.Image(filename=page_path, resolution=resolution) as img:
+    stream.seek(0)
+    with wand.image.Image(file=stream, resolution=resolution) as pages:
+        img = wand.image.Image(image=pages.sequence[page_no])
         if img.alpha_channel:
             img.background_color = wand.image.Color('white')
             img.alpha_channel = 'background'
@@ -39,7 +40,7 @@ class PageImage(object):
         self.page = page
         if original == None:
             self.original = get_page_image(
-                page.pdf.stream.name,
+                page.pdf.stream,
                 page.page_number - 1,
                 resolution
             )

--- a/tests/test-display.py
+++ b/tests/test-display.py
@@ -2,7 +2,7 @@
 import unittest
 import pandas as pd
 import pdfplumber
-import sys, os
+import sys, os, io
 
 import logging
 logging.disable(logging.ERROR)
@@ -29,6 +29,11 @@ class Test(unittest.TestCase):
             "intersection_tolerance": 5
         }
         self.im.debug_tablefinder(settings)
+
+    def test_bytes_stream_to_image(self):
+        path = os.path.join(HERE, "pdfs/nics-background-checks-2015-11.pdf")
+        page = pdfplumber.PDF(io.BytesIO(open(path, 'rb').read())).pages[0]
+        im = page.to_image()
 
     def test_curves(self):
         path = os.path.join(


### PR DESCRIPTION
My app fetches PDF from HTTP and it creates a PDF object using a `io.BytesIO` stream. Since the stream is not opened from a file, it does not have the `name` property which `PageImage` expects it to have.

This commit fixes the issue #124 by using existing stream object to create a wand Image. The stream is already read by `PDFParser` so we need to seek backwards to the beginning.

This should work for both file-stream and byte-stream.