### PR TITLE
cluster_list may put too many entries in a group

### DIFF
--- a/pdfplumber/utils.py
+++ b/pdfplumber/utils.py
@@ -35,7 +35,7 @@ def cluster_list(xs, tolerance=0):
         else:
             groups.append(current_group)
             current_group = [x]
-        last = x
+            last = x
     groups.append(current_group)
     return groups
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,20 @@
+import unittest
+import pdfplumber
+import logging
+from decimal import Decimal
+
+logging.disable(logging.ERROR)
+
+
+class Test(unittest.TestCase):
+
+    def test_cluster_list(self):
+        # For a tolerance of 2, this list of Decimals should be split into three groups
+        test_numbers = list(map(Decimal, ['0', '1.1', '2.2', '3.3', '4.4', '5.5']))
+        expected = [
+            [Decimal('0'), Decimal('1.1')],
+            [Decimal('2.2'), Decimal('3.3')],
+            [Decimal('4.4'), Decimal('5.5')]
+        ]
+        actual = pdfplumber.utils.cluster_list(test_numbers, 2)
+        assert expected == actual


### PR DESCRIPTION
Today if you give pass cluster_list a list of numbers such as `['0', '1.1', '2.2', '3.3', '4.4', '5.5']` with a tolerance of `2` it will put all of those numbers in one group. This happens because `last = x` is executed everytime through the main loopl.  `last = x` should only happen when a new group is created.  

With the fix in place cluster_list will return `[[0, 1.1], [2.2, 3.3], [4.4, 5.5]]`