### PR TITLE
Add missing object type `rect_edge` to `obj_to_edges()`

### DIFF
--- a/pdfplumber/utils.py
+++ b/pdfplumber/utils.py
@@ -460,6 +460,7 @@ def obj_to_edges(obj):
     return {
         "line": lambda x: [ line_to_edge(x) ],
         "rect": rect_to_edges,
+        "rect_edge": rect_to_edges,
         "curve": curve_to_edges,
     }[obj["object_type"]](obj)
 

--- a/tests/test-issues.py
+++ b/tests/test-issues.py
@@ -135,6 +135,11 @@ class Test(unittest.TestCase):
         with pdfplumber.open(path) as pdf:
             page = pdf.pages[0]
             assert len(page.chars) == 5140
+            page.extract_tables({
+                "vertical_strategy": "explicit",
+                "horizontal_strategy": "lines",
+                "explicit_vertical_lines": page.curves + page.edges,
+            })
 
     def test_issue_140(self):
         path = os.path.join(HERE, "pdfs/issue-140-example.pdf")


### PR DESCRIPTION
Method `obj_to_edges()` was added in https://github.com/jsvine/pdfplumber/commit/d68e8813be6ab2ff74d8a8048f3313d48ba91788 but missed out on adding `rect_edge` as a valid key. `rect_edge` is being used in https://github.com/jsvine/pdfplumber/blob/dead89c86d1cac5535d40326adb8ccdcde7d1b5b/pdfplumber/utils.py#L423-L452 and https://github.com/jsvine/pdfplumber/blob/dead89c86d1cac5535d40326adb8ccdcde7d1b5b/pdfplumber/cli.py#L42

Also updated an existing test `test_pr_138()` with a call to `extract_tables` that would raise an error `KeyError: 'rect_edge'` when run on the `master` branch.