### PR TITLE
Allow GitHub Actions workflow to run on pull requests from forked repos

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [push]
+on: [push, pull_request_target]
 
 jobs:
   lint:


### PR DESCRIPTION
I noticed in https://github.com/jsvine/pdfplumber/pull/278 that the checks were stuck at "Waiting for status to be reported". This was happening because in our workflow file we had set it to run on all push commits and apparently, that is not enough for the workflow to run on forked repos. This PR attempts to solve that by adding a `pull_request_target` event trigger so that the workflow is run on PRs raised from forked repos. More information can be found [here](https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull_request_target) and [here](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/).