### PR TITLE
Handle integer/floating type metadata values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [0.5.25] — Unreleased
+### Fixed
+- Fix metadata extraction to handle integer/floating-point values ([#297](https://github.com/jsvine/pdfplumber/issues/297))
+
 ## [0.5.24] — 2020-10-20
 ### Added
 - Added `extra_attrs=[...]` parameter to `.extract_text(...)` ([c8b200e](https://github.com/jsvine/pdfplumber/commit/c8b200e)) ([#28](https://github.com/jsvine/pdfplumber/issues/28))

--- a/pdfplumber/pdf.py
+++ b/pdfplumber/pdf.py
@@ -33,10 +33,10 @@ class PDF(Container):
                 self.metadata[k] = list(map(decode_text, v))
             elif isinstance(v, PSLiteral):
                 self.metadata[k] = decode_text(v.name)
-            elif isinstance(v, bool):
-                self.metadata[k] = v
-            else:
+            elif isinstance(v, (str, bytes)):
                 self.metadata[k] = decode_text(v)
+            else:
+                self.metadata[k] = v
         self.device = PDFPageAggregator(rsrcmgr, laparams=self.laparams)
         self.interpreter = PDFPageInterpreter(rsrcmgr, self.device)
 

--- a/tests/pdfs/issue-297-example.pdf
+++ b/tests/pdfs/issue-297-example.pdf
@@ -1,0 +1,47 @@
+%PDF-1.3
+1 0 obj
+<<
+/Type /Pages
+/Count 1
+/Kids [ 3 0 R ]
+>>
+endobj
+2 0 obj
+<<
+/Producer (PyPDF2)
+/Title (IntMetadata)
+%%Postscript (OFF)
+/Copies 0
+>>
+endobj
+3 0 obj
+<<
+/Type /Page
+/Parent 1 0 R
+/Resources <<
+>>
+/MediaBox [ 0 0 612 792 ]
+>>
+endobj
+4 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+>>
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000009 00000 n 
+0000000068 00000 n 
+0000000160 00000 n 
+0000000250 00000 n 
+trailer
+<<
+/Size 5
+/Root 4 0 R
+/Info 2 0 R
+>>
+startxref
+299
+%%EOF

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -160,3 +160,11 @@ class Test(unittest.TestCase):
         with pdfplumber.open(path) as pdf:
             cropped = pdf.pages[0].crop((0, 0, 1, 1))
             assert cropped.extract_table() is None
+
+    def test_issue_297(self):
+        """
+        Handle integer type metadata
+        """
+        path = os.path.join(HERE, "pdfs/issue-297-example.pdf")
+        with pdfplumber.open(path) as pdf:
+            assert isinstance(pdf.metadata["Copies"], int)


### PR DESCRIPTION
This is a quick fix for issue #297 

A test is yet to be added as I have been unable to edit a metadata value and store it as an integer type. It keeps getting saved as a string. If any of the watchers of this PR can modify the metadata of any of the available PDFs in the repo such that the data type becomes an integer or a float, it would be much appreciated and I'll add a test case for it as well.