### PR TITLE
Format tests according to psf/black and flake8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,10 +27,10 @@ jobs:
         pip install -r requirements-dev.txt
 
     - name: Validate against psf/black
-      run: python -m black --check pdfplumber
+      run: python -m black --check pdfplumber tests
 
     - name: Validate against flake8
-      run: python -m flake8 pdfplumber
+      run: python -m flake8 pdfplumber tests
 
   test:
     needs: lint

--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,12 @@ tests:
 	${PYTHON} -m coverage html
 
 check-black:
-	${PYTHON} -m black pdfplumber --check
+	${PYTHON} -m black --check pdfplumber tests
 
 check-flake:
-	${PYTHON} -m flake8 pdfplumber
+	${PYTHON} -m flake8 pdfplumber tests
 
 lint: check-flake check-black
 
 format:
-	${PYTHON} -m black pdfplumber
+	${PYTHON} -m black pdfplumber tests

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -5,12 +5,13 @@ import pdfplumber
 import sys, os
 
 import logging
+
 logging.disable(logging.ERROR)
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
-class Test(unittest.TestCase):
 
+class Test(unittest.TestCase):
     @classmethod
     def setup_class(self):
         path = os.path.join(HERE, "pdfs/nics-background-checks-2015-11.pdf")
@@ -22,10 +23,10 @@ class Test(unittest.TestCase):
 
     def test_metadata(self):
         metadata = self.pdf.metadata
-        assert(isinstance(metadata["Producer"], str))
+        assert isinstance(metadata["Producer"], str)
 
     def test_pagecount(self):
-        assert(len(self.pdf.pages) == 1)
+        assert len(self.pdf.pages) == 1
 
     def test_page_number(self):
         assert self.pdf.pages[0].page_number == 1
@@ -56,6 +57,7 @@ class Test(unittest.TestCase):
     def test_crop_and_filter(self):
         def test(obj):
             return obj["object_type"] == "char"
+
         bbox = (0, 0, 200, 200)
         original = self.pdf.pages[0]
         cropped = original.crop(bbox)
@@ -84,8 +86,12 @@ class Test(unittest.TestCase):
 
         # via issue #245, should not throw error when using `relative=True`
         bottom = page.crop((0, 0.8 * float(page.height), page.width, page.height))
-        bottom_left = bottom.crop((0, 0, 0.5 * float(bottom.width), bottom.height), relative=True)
-        bottom_right = bottom.crop((0.5 * float(bottom.width), 0, bottom.width, bottom.height), relative=True)
+        bottom_left = bottom.crop(
+            (0, 0, 0.5 * float(bottom.width), bottom.height), relative=True
+        )
+        bottom_right = bottom.crop(
+            (0.5 * float(bottom.width), 0, bottom.width, bottom.height), relative=True
+        )
 
     def test_invalid_crops(self):
         page = self.pdf.pages[0]
@@ -109,45 +115,48 @@ class Test(unittest.TestCase):
         with pytest.raises(ValueError):
             bottom_left = bottom.crop((0, 0, 0.5 * float(bottom.width), bottom.height))
         with pytest.raises(ValueError):
-            bottom_right = bottom.crop((0.5 * float(bottom.width), 0, bottom.width, bottom.height))
+            bottom_right = bottom.crop(
+                (0.5 * float(bottom.width), 0, bottom.width, bottom.height)
+            )
 
     def test_rotation(self):
-        assert(self.pdf.pages[0].width == 1008)
-        assert(self.pdf.pages[0].height == 612)
+        assert self.pdf.pages[0].width == 1008
+        assert self.pdf.pages[0].height == 612
         path = os.path.join(HERE, "pdfs/nics-background-checks-2015-11-rotated.pdf")
         with pdfplumber.open(path) as rotated:
-            assert(rotated.pages[0].width == 612)
-            assert(rotated.pages[0].height == 1008)
+            assert rotated.pages[0].width == 612
+            assert rotated.pages[0].height == 1008
 
-            assert(rotated.pages[0].cropbox == self.pdf.pages[0].cropbox)
-            assert(rotated.pages[0].bbox != self.pdf.pages[0].bbox)
+            assert rotated.pages[0].cropbox == self.pdf.pages[0].cropbox
+            assert rotated.pages[0].bbox != self.pdf.pages[0].bbox
 
     def test_password(self):
         path = os.path.join(HERE, "pdfs/password-example.pdf")
-        with pdfplumber.open(path, password = "test") as pdf:
-            assert(len(pdf.chars) > 0)
+        with pdfplumber.open(path, password="test") as pdf:
+            assert len(pdf.chars) > 0
 
     def test_colors(self):
         path = os.path.join(HERE, "pdfs/nics-background-checks-2015-11.pdf")
         with pdfplumber.open(path) as pdf:
             rect = pdf.pages[0].rects[0]
-            assert rect['non_stroking_color'] == [0.8, 1, 1]
+            assert rect["non_stroking_color"] == [0.8, 1, 1]
 
     def test_text_colors(self):
         path = os.path.join(HERE, "pdfs/nics-background-checks-2015-11.pdf")
         with pdfplumber.open(path) as pdf:
             char = pdf.pages[0].chars[3358]
-            assert char['non_stroking_color'] == [1, 0, 0]
+            assert char["non_stroking_color"] == [1, 0, 0]
 
     def test_load_with_custom_laparams(self):
         # See https://github.com/jsvine/pdfplumber/issues/168
         path = os.path.join(HERE, "pdfs/cupertino_usd_4-6-16.pdf")
-        laparams = dict(line_margin = 0.2)
-        with pdfplumber.open(path, laparams = laparams) as pdf:
+        laparams = dict(line_margin=0.2)
+        with pdfplumber.open(path, laparams=laparams) as pdf:
             assert float(pdf.pages[0].chars[0]["top"]) == 66.384
 
     def test_loading_pathobj(self):
         from pathlib import Path
+
         path = os.path.join(HERE, "pdfs/nics-background-checks-2015-11.pdf")
         path_obj = Path(path)
         with pdfplumber.open(path_obj) as pdf:

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -2,7 +2,7 @@
 import unittest
 import pytest
 import pdfplumber
-import sys, os
+import os
 
 import logging
 
@@ -86,10 +86,8 @@ class Test(unittest.TestCase):
 
         # via issue #245, should not throw error when using `relative=True`
         bottom = page.crop((0, 0.8 * float(page.height), page.width, page.height))
-        bottom_left = bottom.crop(
-            (0, 0, 0.5 * float(bottom.width), bottom.height), relative=True
-        )
-        bottom_right = bottom.crop(
+        bottom.crop((0, 0, 0.5 * float(bottom.width), bottom.height), relative=True)
+        bottom.crop(
             (0.5 * float(bottom.width), 0, bottom.width, bottom.height), relative=True
         )
 
@@ -113,11 +111,9 @@ class Test(unittest.TestCase):
         # via issue #245
         bottom = page.crop((0, 0.8 * float(page.height), page.width, page.height))
         with pytest.raises(ValueError):
-            bottom_left = bottom.crop((0, 0, 0.5 * float(bottom.width), bottom.height))
+            bottom.crop((0, 0, 0.5 * float(bottom.width), bottom.height))
         with pytest.raises(ValueError):
-            bottom_right = bottom.crop(
-                (0.5 * float(bottom.width), 0, bottom.width, bottom.height)
-            )
+            bottom.crop((0.5 * float(bottom.width), 0, bottom.width, bottom.height))
 
     def test_rotation(self):
         assert self.pdf.pages[0].width == 1008

--- a/tests/test_ca_warn_report.py
+++ b/tests/test_ca_warn_report.py
@@ -6,18 +6,22 @@ from pdfplumber import table
 import sys, os
 
 import logging
+
 logging.disable(logging.ERROR)
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
+
 def fix_row_spaces(row):
-    return [ (x or "").replace(" ", "") for x in row[:3] ] + row[3:]
+    return [(x or "").replace(" ", "") for x in row[:3]] + row[3:]
+
 
 class Test(unittest.TestCase):
-
     @classmethod
     def setup_class(self):
-        self.path = os.path.join(HERE, "pdfs/WARN-Report-for-7-1-2015-to-03-25-2016.pdf")
+        self.path = os.path.join(
+            HERE, "pdfs/WARN-Report-for-7-1-2015-to-03-25-2016.pdf"
+        )
         self.pdf = pdfplumber.open(self.path)
         self.PDF_WIDTH = self.pdf.pages[0].width
 
@@ -26,7 +30,7 @@ class Test(unittest.TestCase):
         self.pdf.close()
 
     def test_page_limiting(self):
-        with pdfplumber.open(self.path, pages = [ 1, 3 ]) as pdf:
+        with pdfplumber.open(self.path, pages=[1, 3]) as pdf:
             assert len(pdf.pages) == 2
             assert pdf.pages[1].page_number == 3
 
@@ -38,22 +42,22 @@ class Test(unittest.TestCase):
 
     def test_parse(self):
 
-        rect_x0_clusters = utils.cluster_list([ r["x0"]
-            for r in self.pdf.pages[1].rects ], tolerance=3)
+        rect_x0_clusters = utils.cluster_list(
+            [r["x0"] for r in self.pdf.pages[1].rects], tolerance=3
+        )
 
-        v_lines = [ x[0] for x in rect_x0_clusters ]
+        v_lines = [x[0] for x in rect_x0_clusters]
 
         def parse_page(page):
-            data = page.extract_table({
-                "vertical_strategy": "explicit",
-                "explicit_vertical_lines": v_lines
-            })
-            without_spaces = [ fix_row_spaces(row) for row in data ]
+            data = page.extract_table(
+                {"vertical_strategy": "explicit", "explicit_vertical_lines": v_lines}
+            )
+            without_spaces = [fix_row_spaces(row) for row in data]
             return without_spaces
 
         parsed = parse_page(self.pdf.pages[0])
 
-        assert(parsed[0] == [
+        assert parsed[0] == [
             "NoticeDate",
             "Effective",
             "Received",
@@ -61,9 +65,9 @@ class Test(unittest.TestCase):
             "City",
             "No. Of",
             "Layoff/Closure",
-        ])
+        ]
 
-        assert(parsed[1] == [
+        assert parsed[1] == [
             "06/22/2015",
             "03/25/2016",
             "07/01/2015",
@@ -71,23 +75,17 @@ class Test(unittest.TestCase):
             "San Jose",
             "150",
             "Closure Permanent",
-        ])
+        ]
 
     def test_edge_merging(self):
         p0 = self.pdf.pages[0]
-        assert(len(p0.edges) == 364) 
-        assert(len(table.merge_edges(
-            p0.edges,
-            snap_tolerance=3,
-            join_tolerance=3
-        )) == 46)
+        assert len(p0.edges) == 364
+        assert (
+            len(table.merge_edges(p0.edges, snap_tolerance=3, join_tolerance=3)) == 46
+        )
 
     def test_vertices(self):
         p0 = self.pdf.pages[0]
-        edges = table.merge_edges(
-            p0.edges,
-            snap_tolerance=3,
-            join_tolerance=3
-        )
+        edges = table.merge_edges(p0.edges, snap_tolerance=3, join_tolerance=3)
         ixs = table.edges_to_intersections(edges)
-        assert(len(ixs.keys()) == 304) # 38x8
+        assert len(ixs.keys()) == 304  # 38x8

--- a/tests/test_ca_warn_report.py
+++ b/tests/test_ca_warn_report.py
@@ -3,7 +3,7 @@ import unittest
 import pdfplumber
 from pdfplumber import utils
 from pdfplumber import table
-import sys, os
+import os
 
 import logging
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -9,19 +9,21 @@ import sys
 import os
 
 import logging
+
 logging.disable(logging.ERROR)
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
+
 def run(cmd):
-    return Popen(cmd, stdout = PIPE).communicate()[0]
+    return Popen(cmd, stdout=PIPE).communicate()[0]
+
 
 class Test(unittest.TestCase):
-
     @classmethod
     def setup_class(self):
         self.path = os.path.join(HERE, "pdfs/pdffill-demo.pdf")
-        self.pdf = pdfplumber.open(self.path, pages = [ 1, 2, 5 ])
+        self.pdf = pdfplumber.open(self.path, pages=[1, 2, 5])
 
     @classmethod
     def teardown_class(self):
@@ -29,7 +31,9 @@ class Test(unittest.TestCase):
 
     def test_json(self):
         c = json.loads(self.pdf.to_json())
-        assert c["pages"][0]["rects"][0]["bottom"] == float(self.pdf.pages[0].rects[0]["bottom"])
+        assert c["pages"][0]["rects"][0]["bottom"] == float(
+            self.pdf.pages[0].rects[0]["bottom"]
+        )
 
     def test_single_pages(self):
         c = json.loads(self.pdf.pages[0].to_json())
@@ -37,14 +41,14 @@ class Test(unittest.TestCase):
 
     def test_additional_attr_types(self):
         path = os.path.join(HERE, "pdfs/issue-67-example.pdf")
-        with pdfplumber.open(path, pages = [ 1 ]) as pdf:
+        with pdfplumber.open(path, pages=[1]) as pdf:
             c = json.loads(pdf.to_json())
             assert len(c["pages"][0]["images"])
 
     def test_csv(self):
         c = self.pdf.to_csv()
         assert c.split("\r\n")[1] == (
-            'char,1,45.83,58.826,656.82,674.82,117.18,117.18,135.18,12.996,'
+            "char,1,45.83,58.826,656.82,674.82,117.18,117.18,135.18,12.996,"
             '18.0,12.996,,,,,,TimesNewRomanPSMT,,,,"(0, 0, 0)",,,18.0,,,,,Y,,1,'
         )
 
@@ -54,24 +58,27 @@ class Test(unittest.TestCase):
         c_from_io = io.read()
         assert c == c_from_io
 
-
     def test_cli(self):
-        res = run([
-             sys.executable,
-             "-m",
-             "pdfplumber.cli",
-             self.path,
-             "--format",
-             "json",
-             "--pages",
-             "1-2",
-             "5",
-             "--indent",
-             "2",
-        ])
+        res = run(
+            [
+                sys.executable,
+                "-m",
+                "pdfplumber.cli",
+                self.path,
+                "--format",
+                "json",
+                "--pages",
+                "1-2",
+                "5",
+                "--indent",
+                "2",
+            ]
+        )
 
         c = json.loads(res)
         assert c["pages"][0]["page_number"] == 1
         assert c["pages"][1]["page_number"] == 2
         assert c["pages"][2]["page_number"] == 5
-        assert c["pages"][0]["rects"][0]["bottom"] == float(self.pdf.pages[0].rects[0]["bottom"])
+        assert c["pages"][0]["rects"][0]["bottom"] == float(
+            self.pdf.pages[0].rects[0]["bottom"]
+        )

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import unittest
-import pytest
 import pdfplumber
 from subprocess import Popen, PIPE
 from io import StringIO

--- a/tests/test_dedupe_chars.py
+++ b/tests/test_dedupe_chars.py
@@ -15,7 +15,6 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 
 
 class Test(unittest.TestCase):
-
     @classmethod
     def setup_class(self):
         path = os.path.join(HERE, "pdfs/issue-71-duplicate-chars.pdf")
@@ -29,48 +28,51 @@ class Test(unittest.TestCase):
         page = self.pdf.pages[0]
         table_without_drop_duplicates = page.extract_table()
         table_with_drop_duplicates = page.dedupe_chars().extract_table()
-        last_line_without_drop = table_without_drop_duplicates[1][1].split('\n')[-1]
-        last_line_with_drop = table_with_drop_duplicates[1][1].split('\n')[-1]
+        last_line_without_drop = table_without_drop_duplicates[1][1].split("\n")[-1]
+        last_line_with_drop = table_with_drop_duplicates[1][1].split("\n")[-1]
 
-        assert last_line_without_drop == '微微软软 培培训训课课程程：：  名名模模意意义义一一些些有有意意义义一一些些'
-        assert last_line_with_drop == '微软 培训课程： 名模意义一些有意义一些'
+        assert last_line_without_drop == "微微软软 培培训训课课程程：：  名名模模意意义义一一些些有有意意义义一一些些"
+        assert last_line_with_drop == "微软 培训课程： 名模意义一些有意义一些"
 
     def test_extract_words(self):
         page = self.pdf.pages[0]
-        x0 = Decimal('440.143')
-        x1_without_drop = Decimal('534.992')
-        x1_with_drop = Decimal('534.719')
-        top_windows = Decimal('791.849')
-        top_linux = Decimal('794.357')
-        bottom = Decimal('802.961')
+        x0 = Decimal("440.143")
+        x1_without_drop = Decimal("534.992")
+        x1_with_drop = Decimal("534.719")
+        top_windows = Decimal("791.849")
+        top_linux = Decimal("794.357")
+        bottom = Decimal("802.961")
         last_words_without_drop = page.extract_words()[-1]
         last_words_with_drop = page.dedupe_chars().extract_words()[-1]
 
-        assert last_words_without_drop['x0'] == x0
-        assert last_words_without_drop['x1'] == x1_without_drop
-        assert last_words_without_drop['top'] in (top_windows, top_linux)
-        assert last_words_without_drop['bottom'] == bottom
-        assert last_words_without_drop['upright'] == 1
-        assert last_words_without_drop['text'] == '名名模模意意义义一一些些有有意意义义一一些些'
+        assert last_words_without_drop["x0"] == x0
+        assert last_words_without_drop["x1"] == x1_without_drop
+        assert last_words_without_drop["top"] in (top_windows, top_linux)
+        assert last_words_without_drop["bottom"] == bottom
+        assert last_words_without_drop["upright"] == 1
+        assert last_words_without_drop["text"] == "名名模模意意义义一一些些有有意意义义一一些些"
 
-        assert last_words_with_drop['x0'] == x0
-        assert last_words_with_drop['x1'] == x1_with_drop
-        assert last_words_with_drop['top'] in (top_windows, top_linux)
-        assert last_words_with_drop['bottom'] == bottom
-        assert last_words_with_drop['upright'] == 1
-        assert last_words_with_drop['text'] == '名模意义一些有意义一些'
+        assert last_words_with_drop["x0"] == x0
+        assert last_words_with_drop["x1"] == x1_with_drop
+        assert last_words_with_drop["top"] in (top_windows, top_linux)
+        assert last_words_with_drop["bottom"] == bottom
+        assert last_words_with_drop["upright"] == 1
+        assert last_words_with_drop["text"] == "名模意义一些有意义一些"
 
     def test_extract_text(self):
         page = self.pdf.pages[0]
-        last_line_without_drop = page.extract_text().split('\n')[-1]
-        last_line_with_drop = page.dedupe_chars().extract_text().split('\n')[-1]
+        last_line_without_drop = page.extract_text().split("\n")[-1]
+        last_line_with_drop = page.dedupe_chars().extract_text().split("\n")[-1]
 
-        assert last_line_without_drop == '微微软软 培培训训课课程程：：  名名模模意意义义一一些些有有意意义义一一些些'
-        assert last_line_with_drop == '微软 培训课程： 名模意义一些有意义一些'
+        assert last_line_without_drop == "微微软软 培培训训课课程程：：  名名模模意意义义一一些些有有意意义义一一些些"
+        assert last_line_with_drop == "微软 培训课程： 名模意义一些有意义一些"
 
     def test_extract_text2(self):
         path = os.path.join(HERE, "pdfs/issue-71-duplicate-chars-2.pdf")
         pdf = pdfplumber.open(path)
         page = pdf.pages[0]
 
-        assert page.dedupe_chars().extract_text(y_tolerance=6).splitlines()[4] == "UE 8.  Circulation - Métabolismes"
+        assert (
+            page.dedupe_chars().extract_text(y_tolerance=6).splitlines()[4]
+            == "UE 8.  Circulation - Métabolismes"
+        )

--- a/tests/test_dedupe_chars.py
+++ b/tests/test_dedupe_chars.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python
 import unittest
-import pytest
-import sys, os
+import os
 import logging
 
 import pdfplumber
-from pdfplumber import table
 from pdfplumber.utils import Decimal
 
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -4,12 +4,13 @@ import pdfplumber
 import sys, os, io
 
 import logging
+
 logging.disable(logging.ERROR)
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
-class Test(unittest.TestCase):
 
+class Test(unittest.TestCase):
     @classmethod
     def setup_class(self):
         path = os.path.join(HERE, "pdfs/nics-background-checks-2015-11.pdf")
@@ -30,22 +31,16 @@ class Test(unittest.TestCase):
 
     def test_debug_tablefinder(self):
         self.im.reset()
-        settings = {
-            "horizontal_strategy": "text",
-            "intersection_tolerance": 5
-        }
+        settings = {"horizontal_strategy": "text", "intersection_tolerance": 5}
         self.im.debug_tablefinder(settings)
 
     def test_bytes_stream_to_image(self):
         path = os.path.join(HERE, "pdfs/nics-background-checks-2015-11.pdf")
-        page = pdfplumber.PDF(io.BytesIO(open(path, 'rb').read())).pages[0]
+        page = pdfplumber.PDF(io.BytesIO(open(path, "rb").read())).pages[0]
         im = page.to_image()
 
     def test_curves(self):
-        path = os.path.join(
-            HERE,
-            "../examples/pdfs/ag-energy-round-up-2017-02-24.pdf"
-        )
+        path = os.path.join(HERE, "../examples/pdfs/ag-energy-round-up-2017-02-24.pdf")
         page = pdfplumber.open(path).pages[0]
         im = page.to_image()
         im.draw_lines(page.curves)

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 import unittest
 import pdfplumber
-import sys, os, io
+import os
+import io
 
 import logging
 
@@ -37,7 +38,7 @@ class Test(unittest.TestCase):
     def test_bytes_stream_to_image(self):
         path = os.path.join(HERE, "pdfs/nics-background-checks-2015-11.pdf")
         page = pdfplumber.PDF(io.BytesIO(open(path, "rb").read())).pages[0]
-        im = page.to_image()
+        page.to_image()
 
     def test_curves(self):
         path = os.path.join(HERE, "../examples/pdfs/ag-energy-round-up-2017-02-24.pdf")

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -13,7 +13,8 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 class Test(unittest.TestCase):
     def test_issue_13(self):
         """
-        Test slightly simplified from gist here: https://github.com/jsvine/pdfplumber/issues/13
+        Test slightly simplified from gist here:
+        https://github.com/jsvine/pdfplumber/issues/13
         """
         pdf = pdfplumber.open(
             os.path.join(HERE, "pdfs/issue-13-151201DSP-Fond-581-90D.pdf")
@@ -25,7 +26,7 @@ class Test(unittest.TestCase):
         RECT_TOLERANCE = 2
 
         def filter_rects(rects):
-            ## Just get the rects that are the right size to be checkboxes
+            # Just get the rects that are the right size to be checkboxes
             rects_found = []
             for rect in rects:
                 if (
@@ -38,13 +39,15 @@ class Test(unittest.TestCase):
             return rects_found
 
         def determine_if_checked(checkbox, curve_list):
-            # This figures out if the bounding box of (either) line used to make
-            # one half of the 'x' is the right size and overlaps with a rectangle.
-            # This isn't foolproof, but works for this case.
-            # It's not totally clear (to me) how common this style of checkboxes
-            # are used, and whether this is useful approach to them.
-            # Also note there should be *two* matching LTCurves for each checkbox.
-            # But here we only test there's at least one.
+            """
+            This figures out if the bounding box of (either) line used to make
+            one half of the 'x' is the right size and overlaps with a rectangle.
+            This isn't foolproof, but works for this case.
+            It's not totally clear (to me) how common this style of checkboxes
+            are used, and whether this is useful approach to them.
+            Also note there should be *two* matching LTCurves for each checkbox.
+            But here we only test there's at least one.
+            """
 
             for curve in curve_list:
 
@@ -117,13 +120,13 @@ class Test(unittest.TestCase):
         path = os.path.join(HERE, "pdfs/issue-90-example.pdf")
         with pdfplumber.open(path) as pdf:
             page = pdf.pages[0]
-            words = page.extract_words()
+            page.extract_words()
 
     def test_pr_136(self):
         path = os.path.join(HERE, "pdfs/pr-136-example.pdf")
         with pdfplumber.open(path) as pdf:
             page = pdf.pages[0]
-            words = page.extract_words()
+            page.extract_words()
 
     def test_pr_138(self):
         path = os.path.join(HERE, "pdfs/pr-138-example.pdf")

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -4,12 +4,13 @@ import pdfplumber
 import os
 
 import logging
+
 logging.disable(logging.ERROR)
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
-class Test(unittest.TestCase):
 
+class Test(unittest.TestCase):
     def test_issue_13(self):
         """
         Test slightly simplified from gist here: https://github.com/jsvine/pdfplumber/issues/13
@@ -27,35 +28,43 @@ class Test(unittest.TestCase):
             ## Just get the rects that are the right size to be checkboxes
             rects_found = []
             for rect in rects:
-                if ( rect['height'] > ( RECT_HEIGHT - RECT_TOLERANCE )   
-                    and ( rect['height'] < RECT_HEIGHT + RECT_TOLERANCE) 
-                    and ( rect['width'] < RECT_WIDTH + RECT_TOLERANCE) 
-                    and ( rect['width'] < RECT_WIDTH + RECT_TOLERANCE) ):
+                if (
+                    rect["height"] > (RECT_HEIGHT - RECT_TOLERANCE)
+                    and (rect["height"] < RECT_HEIGHT + RECT_TOLERANCE)
+                    and (rect["width"] < RECT_WIDTH + RECT_TOLERANCE)
+                    and (rect["width"] < RECT_WIDTH + RECT_TOLERANCE)
+                ):
                     rects_found.append(rect)
             return rects_found
 
         def determine_if_checked(checkbox, curve_list):
             # This figures out if the bounding box of (either) line used to make
             # one half of the 'x' is the right size and overlaps with a rectangle.
-            # This isn't foolproof, but works for this case. 
+            # This isn't foolproof, but works for this case.
             # It's not totally clear (to me) how common this style of checkboxes
             # are used, and whether this is useful approach to them.
             # Also note there should be *two* matching LTCurves for each checkbox.
-            # But here we only test there's at least one. 
+            # But here we only test there's at least one.
 
             for curve in curve_list:
 
-                if ( checkbox['height'] > ( RECT_HEIGHT - RECT_TOLERANCE )   
-                    and ( checkbox['height'] < RECT_HEIGHT + RECT_TOLERANCE) 
-                    and ( checkbox['width'] < RECT_WIDTH + RECT_TOLERANCE) 
-                    and ( checkbox['width'] < RECT_WIDTH + RECT_TOLERANCE) ):
+                if (
+                    checkbox["height"] > (RECT_HEIGHT - RECT_TOLERANCE)
+                    and (checkbox["height"] < RECT_HEIGHT + RECT_TOLERANCE)
+                    and (checkbox["width"] < RECT_WIDTH + RECT_TOLERANCE)
+                    and (checkbox["width"] < RECT_WIDTH + RECT_TOLERANCE)
+                ):
 
                     xmatch = False
                     ymatch = False
 
-                    if ( max(checkbox['x0'], curve['x0']) <= min(checkbox['x1'], curve['x1']) ):
+                    if max(checkbox["x0"], curve["x0"]) <= min(
+                        checkbox["x1"], curve["x1"]
+                    ):
                         xmatch = True
-                    if ( max(checkbox['y0'], curve['y0']) <= min(checkbox['y1'], curve['y1']) ):
+                    if max(checkbox["y0"], curve["y0"]) <= min(
+                        checkbox["y1"], curve["y1"]
+                    ):
                         ymatch = True
                     if xmatch and ymatch:
                         return True
@@ -66,44 +75,33 @@ class Test(unittest.TestCase):
         curves = p0.objects["curve"]
         rects = filter_rects(p0.objects["rect"])
 
-        n_checked = sum([ determine_if_checked(rect, curves)
-            for rect in rects ])
+        n_checked = sum([determine_if_checked(rect, curves) for rect in rects])
 
-        assert(n_checked == 5)
+        assert n_checked == 5
         pdf.close()
 
     def test_issue_14(self):
-        pdf = pdfplumber.open(
-            os.path.join(HERE, "pdfs/cupertino_usd_4-6-16.pdf")
-        )
+        pdf = pdfplumber.open(os.path.join(HERE, "pdfs/cupertino_usd_4-6-16.pdf"))
         assert len(pdf.objects)
         pdf.close()
 
     def test_issue_21(self):
-        pdf = pdfplumber.open(
-            os.path.join(HERE, "pdfs/150109DSP-Milw-505-90D.pdf")
-        )
+        pdf = pdfplumber.open(os.path.join(HERE, "pdfs/150109DSP-Milw-505-90D.pdf"))
         assert len(pdf.objects)
         pdf.close()
 
     def test_issue_33(self):
-        pdf = pdfplumber.open(
-            os.path.join(HERE, "pdfs/issue-33-lorem-ipsum.pdf")
-        )
+        pdf = pdfplumber.open(os.path.join(HERE, "pdfs/issue-33-lorem-ipsum.pdf"))
         assert len(pdf.metadata.keys())
         pdf.close()
-        
+
     def test_issue_53(self):
-        pdf = pdfplumber.open(
-            os.path.join(HERE, "pdfs/issue-53-example.pdf")
-        )
+        pdf = pdfplumber.open(os.path.join(HERE, "pdfs/issue-53-example.pdf"))
         assert len(pdf.objects)
         pdf.close()
 
     def test_issue_67(self):
-        pdf = pdfplumber.open(
-            os.path.join(HERE, "pdfs/issue-67-example.pdf")
-        )
+        pdf = pdfplumber.open(os.path.join(HERE, "pdfs/issue-67-example.pdf"))
         assert len(pdf.metadata.keys())
         pdf.close()
 
@@ -132,11 +130,13 @@ class Test(unittest.TestCase):
         with pdfplumber.open(path) as pdf:
             page = pdf.pages[0]
             assert len(page.chars) == 5140
-            page.extract_tables({
-                "vertical_strategy": "explicit",
-                "horizontal_strategy": "lines",
-                "explicit_vertical_lines": page.curves + page.edges,
-            })
+            page.extract_tables(
+                {
+                    "vertical_strategy": "explicit",
+                    "horizontal_strategy": "lines",
+                    "explicit_vertical_lines": page.curves + page.edges,
+                }
+            )
 
     def test_issue_140(self):
         path = os.path.join(HERE, "pdfs/issue-140-example.pdf")
@@ -174,4 +174,6 @@ class Test(unittest.TestCase):
         """
         path = os.path.join(HERE, "pdfs/issue-316-example.pdf")
         with pdfplumber.open(path) as pdf:
-            assert pdf.metadata["Changes"][0]["CreationDate"] == "D:20061207105020Z00'00'"
+            assert (
+                pdf.metadata["Changes"][0]["CreationDate"] == "D:20061207105020Z00'00'"
+            )

--- a/tests/test_list_metadata.py
+++ b/tests/test_list_metadata.py
@@ -4,12 +4,13 @@ import pdfplumber
 import sys, os
 
 import logging
+
 logging.disable(logging.ERROR)
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
-class Test(unittest.TestCase):
 
+class Test(unittest.TestCase):
     def test_load(self):
         path = os.path.join(HERE, "pdfs/cupertino_usd_4-6-16.pdf")
         with pdfplumber.open(path) as pdf:

--- a/tests/test_list_metadata.py
+++ b/tests/test_list_metadata.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import unittest
 import pdfplumber
-import sys, os
+import os
 
 import logging
 

--- a/tests/test_nics_report.py
+++ b/tests/test_nics_report.py
@@ -3,7 +3,7 @@ import unittest
 import pdfplumber
 from operator import itemgetter
 from pdfplumber.utils import within_bbox, collate_chars
-import sys, os
+import os
 
 import logging
 

--- a/tests/test_nics_report.py
+++ b/tests/test_nics_report.py
@@ -6,6 +6,7 @@ from pdfplumber.utils import within_bbox, collate_chars
 import sys, os
 
 import logging
+
 logging.disable(logging.ERROR)
 
 HERE = os.path.abspath(os.path.dirname(__file__))
@@ -35,8 +36,9 @@ COLUMNS = [
     "return_to_seller_handgun",
     "return_to_seller_long_gun",
     "return_to_seller_other",
-    "totals"
+    "totals",
 ]
+
 
 class Test(unittest.TestCase):
     @classmethod
@@ -56,52 +58,57 @@ class Test(unittest.TestCase):
     def test_plain(self):
         page = self.pdf.pages[0]
         cropped = page.crop((0, 80, self.PDF_WIDTH, 485))
-        table = cropped.extract_table({
-            "horizontal_strategy": "text",
-            "explicit_vertical_lines": [
-                min(map(itemgetter("x0"), cropped.chars))
-            ],
-            "intersection_tolerance": 5
-        })
+        table = cropped.extract_table(
+            {
+                "horizontal_strategy": "text",
+                "explicit_vertical_lines": [min(map(itemgetter("x0"), cropped.chars))],
+                "intersection_tolerance": 5,
+            }
+        )
 
         def parse_value(k, x):
-            if k == 0: return x
-            if x in (None, ""): return None
+            if k == 0:
+                return x
+            if x in (None, ""):
+                return None
             return int(x.replace(",", ""))
 
         def parse_row(row):
-            return dict((COLUMNS[i], parse_value(i, v))
-                for i, v in enumerate(row))
+            return dict((COLUMNS[i], parse_value(i, v)) for i, v in enumerate(row))
 
-        parsed_table = [ parse_row(row) for row in table ]
+        parsed_table = [parse_row(row) for row in table]
 
         # [1:] because first column is state name
         for c in COLUMNS[1:]:
             total = parsed_table[-1][c]
             colsum = sum(row[c] or 0 for row in parsed_table)
-            assert(colsum == (total * 2))
+            assert colsum == (total * 2)
 
         month_chars = within_bbox(page.chars, (0, 35, self.PDF_WIDTH, 65))
         month_text = collate_chars(month_chars)
-        assert(month_text == "November - 2015")
+        assert month_text == "November - 2015"
 
     def test_filter(self):
         page = self.pdf.pages[0]
+
         def test(obj):
             if obj["object_type"] == "char":
                 if obj["size"] < 15:
                     return False
             return True
+
         filtered = page.filter(test)
         text = filtered.extract_text()
-        assert(text == "NICS Firearm Background Checks\nNovember - 2015")
+        assert text == "NICS Firearm Background Checks\nNovember - 2015"
 
     def test_text_only_strategy(self):
         cropped = self.pdf.pages[0].crop((0, 80, self.PDF_WIDTH, 475))
-        table = cropped.extract_table(dict(
-            horizontal_strategy="text",
-            vertical_strategy="text",
-        ))
+        table = cropped.extract_table(
+            dict(
+                horizontal_strategy="text",
+                vertical_strategy="text",
+            )
+        )
         assert table[0][0] == "Alabama"
         assert table[0][22] == "71,137"
         assert table[-1][0] == "Wyoming"
@@ -109,34 +116,45 @@ class Test(unittest.TestCase):
 
     def test_explicit_horizontal(self):
         cropped = self.pdf.pages[0].crop((0, 80, self.PDF_WIDTH, 475))
-        table = cropped.find_tables(dict(
-            horizontal_strategy="text",
-            vertical_strategy="text",
-        ))[0]
+        table = cropped.find_tables(
+            dict(
+                horizontal_strategy="text",
+                vertical_strategy="text",
+            )
+        )[0]
 
-        h_positions = [row.cells[0][1] for row in table.rows] + [table.rows[-1].cells[0][3]]
+        h_positions = [row.cells[0][1] for row in table.rows] + [
+            table.rows[-1].cells[0][3]
+        ]
 
-        t_explicit = cropped.find_tables(dict(
-            horizontal_strategy="explicit",
-            vertical_strategy="text",
-            explicit_horizontal_lines=h_positions,
-        ))[0]
+        t_explicit = cropped.find_tables(
+            dict(
+                horizontal_strategy="explicit",
+                vertical_strategy="text",
+                explicit_horizontal_lines=h_positions,
+            )
+        )[0]
 
         assert table.extract() == t_explicit.extract()
 
-        h_objs = [ {
-            "x0": 0,
-            "x1": self.PDF_WIDTH,
-            "width": self.PDF_WIDTH,
-            "top": h,
-            "bottom": h,
-            "object_type": "line",
-        } for h in h_positions ]
+        h_objs = [
+            {
+                "x0": 0,
+                "x1": self.PDF_WIDTH,
+                "width": self.PDF_WIDTH,
+                "top": h,
+                "bottom": h,
+                "object_type": "line",
+            }
+            for h in h_positions
+        ]
 
-        t_explicit_objs = cropped.find_tables(dict(
-            horizontal_strategy="explicit",
-            vertical_strategy="text",
-            explicit_horizontal_lines=h_objs,
-        ))[0]
+        t_explicit_objs = cropped.find_tables(
+            dict(
+                horizontal_strategy="explicit",
+                vertical_strategy="text",
+                explicit_horizontal_lines=h_objs,
+            )
+        )[0]
 
         assert table.extract() == t_explicit_objs.extract()

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -6,12 +6,13 @@ from pdfplumber import table
 import sys, os
 
 import logging
+
 logging.disable(logging.ERROR)
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
-class Test(unittest.TestCase):
 
+class Test(unittest.TestCase):
     @classmethod
     def setup_class(self):
         path = os.path.join(HERE, "pdfs/pdffill-demo.pdf")
@@ -27,26 +28,31 @@ class Test(unittest.TestCase):
 
     def test_table_settings_errors(self):
         with pytest.raises(ValueError):
-            tf = table.TableFinder(self.pdf.pages[0], { "strategy": "x" })
+            tf = table.TableFinder(self.pdf.pages[0], {"strategy": "x"})
             td.get_edges()
 
         with pytest.raises(ValueError):
-            tf = table.TableFinder(self.pdf.pages[0], { "vertical_strategy": "x" })
+            tf = table.TableFinder(self.pdf.pages[0], {"vertical_strategy": "x"})
             td.get_edges()
 
         with pytest.raises(ValueError):
-            tf = table.TableFinder(self.pdf.pages[0], {
-                "vertical_strategy": "explicit",
-                "explicit_vertical_lines": [],
-            })
+            tf = table.TableFinder(
+                self.pdf.pages[0],
+                {
+                    "vertical_strategy": "explicit",
+                    "explicit_vertical_lines": [],
+                },
+            )
 
     def test_edges_strict(self):
         path = os.path.join(HERE, "pdfs/issue-140-example.pdf")
         with pdfplumber.open(path) as pdf:
-            t = pdf.pages[0].extract_table({
-                "vertical_strategy": "lines_strict",
-                "horizontal_strategy": "lines_strict"
-            })
+            t = pdf.pages[0].extract_table(
+                {
+                    "vertical_strategy": "lines_strict",
+                    "horizontal_strategy": "lines_strict",
+                }
+            )
 
         assert t[-1] == [
             "",
@@ -57,19 +63,22 @@ class Test(unittest.TestCase):
             "$ 0.61",
             "$ 253.15",
             "0.0000",
-            ""
+            "",
         ]
 
     def test_explicit_desc_decimalization(self):
         """
         See issue #290
         """
-        tf = table.TableFinder(self.pdf.pages[0], {
-            "vertical_strategy": "explicit",
-            "explicit_vertical_lines": [ 100, 200, 300 ],
-            "horizontal_strategy": "explicit",
-            "explicit_horizontal_lines": [ 100, 200, 300 ],
-        })
+        tf = table.TableFinder(
+            self.pdf.pages[0],
+            {
+                "vertical_strategy": "explicit",
+                "explicit_vertical_lines": [100, 200, 300],
+                "horizontal_strategy": "explicit",
+                "explicit_horizontal_lines": [100, 200, 300],
+            },
+        )
         assert tf.tables[0].extract()
 
     def test_text_without_words(self):

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -3,7 +3,7 @@ import unittest
 import pytest
 import pdfplumber
 from pdfplumber import table
-import sys, os
+import os
 
 import logging
 
@@ -29,11 +29,11 @@ class Test(unittest.TestCase):
     def test_table_settings_errors(self):
         with pytest.raises(ValueError):
             tf = table.TableFinder(self.pdf.pages[0], {"strategy": "x"})
-            td.get_edges()
+            tf.get_edges()
 
         with pytest.raises(ValueError):
             tf = table.TableFinder(self.pdf.pages[0], {"vertical_strategy": "x"})
-            td.get_edges()
+            tf.get_edges()
 
         with pytest.raises(ValueError):
             tf = table.TableFinder(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,12 +11,13 @@ from operator import itemgetter
 import sys, os
 
 import logging
+
 logging.disable(logging.ERROR)
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
-class Test(unittest.TestCase):
 
+class Test(unittest.TestCase):
     @classmethod
     def setup_class(self):
         path = os.path.join(HERE, "pdfs/pdffill-demo.pdf")
@@ -47,14 +48,14 @@ class Test(unittest.TestCase):
     def test_resolve_all(self):
         info = self.pdf.doc.xrefs[0].trailer["Info"]
         assert type(info) == PDFObjRef
-        a = [ { "info": info } ]
+        a = [{"info": info}]
         a_res = utils.resolve_all(a)
         assert a_res[0]["info"]["Producer"] == self.pdf.doc.info[0]["Producer"]
 
     def test_decimalize(self):
         d = Decimal("1.011")
         assert utils.decimalize(1.011) == d
-        assert [ utils.decimalize(1.011) ] == [ d ]
+        assert [utils.decimalize(1.011)] == [d]
         assert utils.decimalize(d) == d
         assert id(utils.decimalize(d)) == id(d)
         assert utils.decimalize(1) == Decimal("1")
@@ -62,7 +63,7 @@ class Test(unittest.TestCase):
             utils.decimalize("1")
 
     def test_decode_psl_list(self):
-        a = [ PSLiteral("test"), "test_2" ]
+        a = [PSLiteral("test"), "test_2"]
         assert utils.decode_psl_list(a) == ["test", "test_2"]
 
     def test_extract_words(self):
@@ -70,7 +71,7 @@ class Test(unittest.TestCase):
         with pdfplumber.open(path) as pdf:
             p = pdf.pages[0]
             words = p.extract_words(vertical_ttb=False)
-            words_attr = p.extract_words(vertical_ttb=False, extra_attrs = [ "size" ])
+            words_attr = p.extract_words(vertical_ttb=False, extra_attrs=["size"])
             words_w_spaces = p.extract_words(vertical_ttb=False, keep_blank_chars=True)
             words_rtl = p.extract_words(horizontal_ltr=False)
 
@@ -91,20 +92,19 @@ class Test(unittest.TestCase):
 
     def test_bad_word_extraction_settings(self):
         with pytest.raises(ValueError):
-            self.pdf.pages[0].extract_words(not_real_param = True)
+            self.pdf.pages[0].extract_words(not_real_param=True)
 
     def test_text_flow(self):
         path = os.path.join(HERE, "pdfs/federal-register-2020-17221.pdf")
 
         def words_to_text(words):
-            grouped = groupby(words, key = itemgetter("top"))
-            lines = [ " ".join(word["text"] for word in grp)
-                for top, grp in grouped ]
+            grouped = groupby(words, key=itemgetter("top"))
+            lines = [" ".join(word["text"] for word in grp) for top, grp in grouped]
             return "\n".join(lines)
 
         with pdfplumber.open(path) as pdf:
             p0 = pdf.pages[0]
-            using_flow = p0.extract_words(use_text_flow = True)
+            using_flow = p0.extract_words(use_text_flow=True)
             not_using_flow = p0.extract_words()
 
         target_text = (
@@ -120,22 +120,24 @@ class Test(unittest.TestCase):
 
     def test_extract_text(self):
         text = self.pdf.pages[0].extract_text()
-        goal = "\n".join([
-            "First Page Previous Page Next Page Last Page",
-            "Print",
-            "PDFill: PDF Drawing",
-            "You can open a PDF or create a blank PDF by PDFill.",
-            "Online Help",
-            "Here are the PDF drawings created by PDFill",
-            "Please save into a new PDF to see the effect!",
-            "Goto Page 2: Line Tool",
-            "Goto Page 3: Arrow Tool",
-            "Goto Page 4: Tool for Rectangle, Square and Rounded Corner",
-            "Goto Page 5: Tool for Circle, Ellipse, Arc, Pie",
-            "Goto Page 6: Tool for Basic Shapes",
-            "Goto Page 7: Tool for Curves",
-            "Here are the tools to change line width, style, arrow style and colors",
-        ])
+        goal = "\n".join(
+            [
+                "First Page Previous Page Next Page Last Page",
+                "Print",
+                "PDFill: PDF Drawing",
+                "You can open a PDF or create a blank PDF by PDFill.",
+                "Online Help",
+                "Here are the PDF drawings created by PDFill",
+                "Please save into a new PDF to see the effect!",
+                "Goto Page 2: Line Tool",
+                "Goto Page 3: Arrow Tool",
+                "Goto Page 4: Tool for Rectangle, Square and Rounded Corner",
+                "Goto Page 5: Tool for Circle, Ellipse, Arc, Pie",
+                "Goto Page 6: Tool for Basic Shapes",
+                "Goto Page 7: Tool for Curves",
+                "Here are the tools to change line width, style, arrow style and colors",
+            ]
+        )
 
         assert text == goal
         assert self.pdf.pages[0].crop((0, 0, 1, 1)).extract_text() == None
@@ -143,7 +145,7 @@ class Test(unittest.TestCase):
     def test_intersects_bbox(self):
         objs = [
             # Is same as bbox
-            { 
+            {
                 "x0": 0,
                 "top": 0,
                 "x1": 20,
@@ -287,7 +289,7 @@ class Test(unittest.TestCase):
         c["x0"] = 7
         c["x1"] = 12
 
-        a_new, b_new, c_new = utils.snap_objects([ a, b, c ], "x0", 1)
+        a_new, b_new, c_new = utils.snap_objects([a, b, c], "x0", 1)
         assert a_new == b_new == c_new
 
     def test_filter_edges(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,7 @@ from pdfminer.psparser import PSLiteral
 from decimal import Decimal
 from itertools import groupby
 from operator import itemgetter
-import sys, os
+import os
 
 import logging
 
@@ -120,27 +120,26 @@ class Test(unittest.TestCase):
 
     def test_extract_text(self):
         text = self.pdf.pages[0].extract_text()
-        goal = "\n".join(
-            [
-                "First Page Previous Page Next Page Last Page",
-                "Print",
-                "PDFill: PDF Drawing",
-                "You can open a PDF or create a blank PDF by PDFill.",
-                "Online Help",
-                "Here are the PDF drawings created by PDFill",
-                "Please save into a new PDF to see the effect!",
-                "Goto Page 2: Line Tool",
-                "Goto Page 3: Arrow Tool",
-                "Goto Page 4: Tool for Rectangle, Square and Rounded Corner",
-                "Goto Page 5: Tool for Circle, Ellipse, Arc, Pie",
-                "Goto Page 6: Tool for Basic Shapes",
-                "Goto Page 7: Tool for Curves",
-                "Here are the tools to change line width, style, arrow style and colors",
-            ]
-        )
+        goal_lines = [
+            "First Page Previous Page Next Page Last Page",
+            "Print",
+            "PDFill: PDF Drawing",
+            "You can open a PDF or create a blank PDF by PDFill.",
+            "Online Help",
+            "Here are the PDF drawings created by PDFill",
+            "Please save into a new PDF to see the effect!",
+            "Goto Page 2: Line Tool",
+            "Goto Page 3: Arrow Tool",
+            "Goto Page 4: Tool for Rectangle, Square and Rounded Corner",
+            "Goto Page 5: Tool for Circle, Ellipse, Arc, Pie",
+            "Goto Page 6: Tool for Basic Shapes",
+            "Goto Page 7: Tool for Curves",
+            "Here are the tools to change line width, style, arrow style and colors",
+        ]
+        goal = "\n".join(goal_lines)
 
         assert text == goal
-        assert self.pdf.pages[0].crop((0, 0, 1, 1)).extract_text() == None
+        assert self.pdf.pages[0].crop((0, 0, 1, 1)).extract_text() is None
 
     def test_intersects_bbox(self):
         objs = [


### PR DESCRIPTION
This PR formats the Python files in `tests/` so that they pass repo's `psf/black` and `flake8` linters, and also enforces these formatting guidelines for future PRs and pushes. 

Fairly straightforward, but could still use a second set of eyes.