### PR TITLE
Rework the alpha conversion to remove jaggies

### DIFF
--- a/pdfplumber/display.py
+++ b/pdfplumber/display.py
@@ -21,10 +21,6 @@ DEFAULT_RESOLUTION = 72
 
 
 def get_page_image(stream, page_no, resolution):
-    """
-    For kwargs, see http://docs.wand-py.org/en/latest/wand/image.html#wand.image.Image
-    """
-
     # If we are working with a file object saved to disk
     if hasattr(stream, "name"):
         spec = dict(filename=f"{stream.name}[{page_no}]")
@@ -44,14 +40,10 @@ def get_page_image(stream, page_no, resolution):
         img = postprocess(img_init)
         if img.alpha_channel:
             img.background_color = wand.image.Color("white")
-            img.alpha_channel = "background"
+            img.alpha_channel = "remove"
         with img.convert("png") as png:
             im = PIL.Image.open(BytesIO(png.make_blob()))
-            if "transparency" in im.info:
-                converted = im.convert("RGBA").convert("RGB")
-            else:
-                converted = im.convert("RGB")
-            return converted
+            return im.convert("RGB")
 
 
 class PageImage(object):


### PR DESCRIPTION
The current method doesn't antialias correctly, presumably because the alpha layer is discarded while there is still data. This new method uses wand to handle the background, allowing us also to remove the special case conversion logic.

Also, am I right in saying that  the docstring here is inaccurate? I don't see the kwargs being passed in anywhere. If we were, for example, to support setting the `background` arg, we'd have to support the alpha channel, as transparent is valid. Happy to update the docstring once I get some more context! :)