### PR TITLE
Even if laparams is set, don't extract `anno` objs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 ## [0.5.28] — Unreleased
 ### Fixed
 - Fix `.extract_text(...)` so that it can accept generator objects as its main parameter. ([#385](https://github.com/jsvine/pdfplumber/pull/385)) [h/t @alexreg]
+- Fix page-parsing so that `LTAnno` objects (which have no bounding-box coordinates) are not extracted. (Was only an issue when setting `laparams`.) ([#388](https://github.com/jsvine/pdfplumber/issues/383))
 
 ## [0.5.27] — 2021-02-28
 ### Fixed

--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -221,6 +221,8 @@ class Page(Container):
         objects = {}
         for obj in self.iter_layout_objects(self.layout._objs):
             kind = obj["object_type"]
+            if kind in ["anno"]:
+                continue
             if objects.get(kind) is None:
                 objects[kind] = []
             objects[kind].append(obj)

--- a/tests/test_laparams.py
+++ b/tests/test_laparams.py
@@ -26,3 +26,11 @@ class Test(unittest.TestCase):
             objs = pdf.pages[0].objects
             assert len(objs["textboxhorizontal"]) == 21
             assert len(objs["char"]) == 4408
+            assert "anno" not in objs.keys()
+
+    def test_issue_383(self):
+        with pdfplumber.open(self.path, laparams={}) as pdf:
+            p0 = pdf.pages[0]
+            assert "anno" not in p0.objects.keys()
+            cropped = p0.crop((0, 0, 100, 100))
+            assert len(cropped.objects)


### PR DESCRIPTION
pdfminer.six's `LTAnno` objects are not PDF annotations (which we already provide access to via `.annots`, regardless of whether `laparams` is set), but rather layout annotations. Per [pdfminer.six codebase](https://github.com/pdfminer/pdfminer.six/blob/ef4787d8add35c84ed324e488a0683485b422f45/pdfminer/layout.py#L264-L270):

> Note that, while a LTChar object has actual boundaries, LTAnno objects does not, as these are "virtual" characters, inserted by a layout analyzer according to the relationship between two characters (e.g. a space).

Because they have no boundaries, they cause problems for pdfplumber, which expects bounding-box coordinates for all objects. See, e.g., issue #383, which this commit should fix.