### PR TITLE
Add --laparams to CLI (and make related tweaks)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [0.5.28] — Unreleased
+### Added
+- Add `--laparams` flag to CLI. ([#407](https://github.com/jsvine/pdfplumber/pull/407))
+
+### Changed
+- Change `.convert_csv(...)` to order objects first by page number, rather than object type. ([#407](https://github.com/jsvine/pdfplumber/pull/407))
+- Change `.convert_csv(...)`, `.convert_json(...)`, and CLI so that, by default, they returning all available object types, rather than those in a predefined default list. ([#407](https://github.com/jsvine/pdfplumber/pull/407))
+
 ### Fixed
 - Fix `.extract_text(...)` so that it can accept generator objects as its main parameter. ([#385](https://github.com/jsvine/pdfplumber/pull/385)) [h/t @alexreg]
 - Fix page-parsing so that `LTAnno` objects (which have no bounding-box coordinates) are not extracted. (Was only an issue when setting `laparams`.) ([#388](https://github.com/jsvine/pdfplumber/issues/383))

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ The output will be a CSV containing info about every character, line, and rectan
 |----------|-------------|
 |`--format [format]`| `csv` or `json`. The `json` format returns more information; it includes PDF-level and page-level metadata, plus dictionary-nested attributes.|
 |`--pages [list of pages]`| A space-delimited, `1`-indexed list of pages or hyphenated page ranges. E.g., `1, 11-15`, which would return data for pages 1, 11, 12, 13, 14, and 15.|
-|`--types [list of object types to extract]`| Choices are `char`, `rect`, `line`, `curve`, `image`, `annot`. Defaults to all.|
+|`--types [list of object types to extract]`| Choices are `char`, `rect`, `line`, `curve`, `image`, `annot`, et cetera. Defaults to all available.|
+|`--laparams`| A JSON-formatted string (e.g., `'{"detect_vertical": true}'`) to pass to `pdfplumber.open(..., laparams=...)`.|
 
 ## Python library
 

--- a/pdfplumber/cli.py
+++ b/pdfplumber/cli.py
@@ -3,6 +3,7 @@ from . import convert
 from .pdf import PDF
 import argparse
 from itertools import chain
+import json
 import sys
 
 
@@ -23,12 +24,15 @@ def parse_args(args_raw):
 
     parser.add_argument("--format", choices=["csv", "json"], default="csv")
 
+    parser.add_argument("--types", nargs="+")
+
     parser.add_argument(
-        "--types",
-        nargs="+",
-        default=convert.DEFAULT_TYPES,
-        choices=convert.DEFAULT_TYPES,
+        "--all-types",
+        action="store_true",
+        help="Return all types of objects. Overrides --types.",
     )
+
+    parser.add_argument("--laparams", type=json.loads)
 
     parser.add_argument("--pages", nargs="+", type=parse_page_spec)
 
@@ -46,7 +50,7 @@ def main(args_raw=sys.argv[1:]):
     args = parse_args(args_raw)
     converter = {"csv": convert.to_csv, "json": convert.to_json}[args.format]
     kwargs = {"csv": {}, "json": {"indent": args.indent}}[args.format]
-    with PDF.open(args.infile, pages=args.pages) as pdf:
+    with PDF.open(args.infile, pages=args.pages, laparams=args.laparams) as pdf:
         converter(pdf, sys.stdout, args.types, **kwargs)
 
 

--- a/pdfplumber/cli.py
+++ b/pdfplumber/cli.py
@@ -26,12 +26,6 @@ def parse_args(args_raw):
 
     parser.add_argument("--types", nargs="+")
 
-    parser.add_argument(
-        "--all-types",
-        action="store_true",
-        help="Return all types of objects. Overrides --types.",
-    )
-
     parser.add_argument("--laparams", type=json.loads)
 
     parser.add_argument("--pages", nargs="+", type=parse_page_spec)

--- a/pdfplumber/container.py
+++ b/pdfplumber/container.py
@@ -48,6 +48,22 @@ class Container(object):
         return self.objects.get("char", [])
 
     @property
+    def textboxverticals(self):
+        return self.objects.get("textboxvertical", [])
+
+    @property
+    def textboxhorizontals(self):
+        return self.objects.get("textboxhorizontal", [])
+
+    @property
+    def textlineverticals(self):
+        return self.objects.get("textlinevertical", [])
+
+    @property
+    def textlinehorizontals(self):
+        return self.objects.get("textlinehorizontal", [])
+
+    @property
     def rect_edges(self):
         if hasattr(self, "_rect_edges"):
             return self._rect_edges

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -34,6 +34,15 @@ class Test(unittest.TestCase):
             self.pdf.pages[0].rects[0]["bottom"]
         )
 
+    def test_json_all_types(self):
+        c = json.loads(self.pdf.to_json(types=None))
+        found_types = c["pages"][0].keys()
+        assert "curves" in found_types
+        assert "chars" in found_types
+        assert "lines" in found_types
+        assert "rects" in found_types
+        assert "images" in found_types
+
     def test_single_pages(self):
         c = json.loads(self.pdf.pages[0].to_json())
         assert c["rects"][0]["bottom"] == float(self.pdf.pages[0].rects[0]["bottom"])
@@ -46,7 +55,7 @@ class Test(unittest.TestCase):
 
     def test_csv(self):
         c = self.pdf.to_csv()
-        assert c.split("\r\n")[1] == (
+        assert c.split("\r\n")[2] == (
             "char,1,45.83,58.826,656.82,674.82,117.18,117.18,135.18,12.996,"
             '18.0,12.996,,,,,,TimesNewRomanPSMT,,,,"(0, 0, 0)",,,18.0,,,,,Y,,1,'
         )
@@ -56,6 +65,10 @@ class Test(unittest.TestCase):
         io.seek(0)
         c_from_io = io.read()
         assert c == c_from_io
+
+    def test_csv_all_types(self):
+        c = self.pdf.to_csv(types=None)
+        assert c.split("\r\n")[1].split(",")[0] == "curve"
 
     def test_cli(self):
         res = run(

--- a/tests/test_laparams.py
+++ b/tests/test_laparams.py
@@ -23,10 +23,21 @@ class Test(unittest.TestCase):
 
     def test_with_laparams(self):
         with pdfplumber.open(self.path, laparams={}) as pdf:
-            objs = pdf.pages[0].objects
-            assert len(objs["textboxhorizontal"]) == 21
-            assert len(objs["char"]) == 4408
-            assert "anno" not in objs.keys()
+            page = pdf.pages[0]
+            assert len(page.textboxhorizontals) == 21
+            assert len(page.textlinehorizontals) == 79
+            assert len(page.chars) == 4408
+            assert "anno" not in page.objects.keys()
+
+    def test_vertical_texts(self):
+        path = os.path.join(HERE, "pdfs/issue-192-example.pdf")
+        laparams = {"detect_vertical": True}
+        with pdfplumber.open(path, laparams=laparams) as pdf:
+            page = pdf.pages[0]
+            assert len(page.textlinehorizontals) == 142
+            assert len(page.textboxhorizontals) == 74
+            assert len(page.textlineverticals) == 11
+            assert len(page.textboxverticals) == 6
 
     def test_issue_383(self):
         with pdfplumber.open(self.path, laparams={}) as pdf:


### PR DESCRIPTION
This commit adds an `--laparams` flag to the pdfplumber CLI, giving it more feature parity with the core library. To do so, it makes some internal changes to `convert.py`, including changing the list of objects to convert from *a predefined default list* to *all types extracted*. It also changes the order of `convert_csv`'s output so that objects are sorted first by page number (rather than object type).