### PR TITLE
Pass kwds args to Table.extract from Page.extract_table

### DIFF
--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -256,7 +256,14 @@ class Page(Container):
             return (-len(x.cells), x.bbox[1], x.bbox[0])
 
         largest = list(sorted(tables, key=sorter))[0]
-        return largest.extract()
+
+        extract_kwargs = dict(
+            (k, table_settings["text_" + k])
+            for k in ["x_tolerance", "y_tolerance"]
+            if "text_" + k in table_settings
+        )
+
+        return largest.extract(**extract_kwargs)
 
     def extract_text(self, **kwargs):
         return utils.extract_text(self.chars, **kwargs)


### PR DESCRIPTION
The extract_table method of the Page class does not honour text tolerance settings. Pass the relevant parameters from the table_settings parameter to the Table.extract method.