### PR TITLE
fix chars deduplication for words with intentionally duplicated chars

### DIFF
--- a/pdfplumber/utils.py
+++ b/pdfplumber/utils.py
@@ -200,7 +200,9 @@ def dedupe_chars(chars, tolerance=1):
         for grp, grp_chars in itertools.groupby(sorted_chars, key=key):
             for y_cluster in cluster_objects(grp_chars, "doctop", t):
                 for x_cluster in cluster_objects(y_cluster, "x0", t):
-                    yield sorted(x_cluster, key=pos_key)[0]
+                    # to not remove 'properly' duplicated characters like "otto" or '112'
+                    # always yield every second letter of the cluster
+                    yield from iter(sorted(x_cluster, key=pos_key)[::2])
 
     deduped = yield_unique_chars(chars)
     return sorted(deduped, key=chars.index)


### PR DESCRIPTION
There is a problem with the current deduplication algorithm - it removes "intentionally" duplicated letters.

For example, if we run deduplication on chars `ssttiillll`, we will have `stil`, which is bad. We want `still`.

The solution is simple - instead of returning the first letter of each cluster of grouped characters, return every second character. This way, when the cluster has len=2 we will have 1 letter. When the cluster has len=4 we will have 2 letters. With clusters of len=1 we have 1 letter. Clusters of len=3 we have 2 letters which is neither good nor bad. In theory, this should not happen when the algorithm is run on a duplicated page.

This PR implements this change.