### PR TITLE
Fix bug that crashed table extraction when null value provided for `(text|intersection)_(x|y)_tolerance` keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Fixed
 - Fix slowdown in `.extract_words(...)`/`WordExtractor.iter_chars_to_words(...)` on very long words, caused by repeatedly re-calculating bounding box. ([#483](https://github.com/jsvine/pdfplumber/discussions/483))
 - Handle `UnicodeDecodeError` when trying to decode utf-16-encoded annotations ([#463](https://github.com/jsvine/pdfplumber/issues/463)) [h/t @tungph]
+- Fix crash when extracting tables with null values in `(text|intersection)_(x|y)_tolerance` settings. ([#539](https://github.com/jsvine/pdfplumber/discussions/539)) [h/t @yoavxyoav]
 
 ### Development Changes
 - Add `CONTRIBUTING.md` ([#428](https://github.com/jsvine/pdfplumber/pull/428))

--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -219,6 +219,7 @@ class Page(Container):
         return TableFinder(self, table_settings).tables
 
     def extract_tables(self, table_settings={}):
+        table_settings = TableFinder.resolve_table_settings(table_settings)
         tables = self.find_tables(table_settings)
 
         extract_kwargs = dict(
@@ -230,6 +231,7 @@ class Page(Container):
         return [table.extract(**extract_kwargs) for table in tables]
 
     def extract_table(self, table_settings={}):
+        table_settings = TableFinder.resolve_table_settings(table_settings)
         tables = self.find_tables(table_settings)
 
         if len(tables) == 0:

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -170,3 +170,31 @@ class Test(unittest.TestCase):
                 # Verify that all cell contain real data
                 for cell in t[3]:
                     assert "last" in cell
+
+    def test_discussion_539_null_value(self):
+        """
+        See discussion #539
+        """
+        path = os.path.join(HERE, "pdfs/nics-background-checks-2015-11.pdf")
+        with pdfplumber.open(path) as pdf:
+            page = pdf.pages[0]
+            table_settings = {
+                "vertical_strategy": "lines",
+                "horizontal_strategy": "lines",
+                "explicit_vertical_lines": [],
+                "explicit_horizontal_lines": [],
+                "snap_tolerance": 3,
+                "join_tolerance": 3,
+                "edge_min_length": 3,
+                "min_words_vertical": 3,
+                "min_words_horizontal": 1,
+                "keep_blank_chars": False,
+                "text_tolerance": 3,
+                "text_x_tolerance": None,
+                "text_y_tolerance": None,
+                "intersection_tolerance": 3,
+                "intersection_x_tolerance": None,
+                "intersection_y_tolerance": None,
+            }
+            assert page.extract_table(table_settings)
+            assert page.extract_tables(table_settings)


### PR DESCRIPTION
Resolves bug raised in #539. The issue was happening because, in `TableFinder`, the settings were being cleaned up before the table extraction but in `extract_table(s)`, the updated table settings were not being used and passing in None in the tolerance setting resulted in a comparison between numeric type and None type and that caused the exception. The issue was resolved by creating a static method to cleanup the user-provided table settings and using it for every operation post table extraction.