### PR TITLE
Add snap_x/y_tolerance and join_x/y_tolerance table-extraction settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. The format 
 - Add `utils.merge_bboxes(bboxes)`, which returns the smallest bounding box that contains all bounding boxes in the `bboxes` argument. ([f8d5e70](https://github.com/jsvine/pdfplumber/commit/f8d5e70a509aa9ed3ee565d7d3f97bb5ec67f5a5))
 - Add `--precision` argument to CLI ([#520](https://github.com/jsvine/pdfplumber/pull/520))
 - Add `snap_x_tolerance` and `snap_y_tolerance` to table extraction settings. ([#51](https://github.com/jsvine/pdfplumber/pull/51) + [#475](https://github.com/jsvine/pdfplumber/issues/475)) [h/t @dustindall]
+- Add `join_x_tolerance` and `join_y_tolerance` to table extraction settings.
 
 ## Changed
 - Upgrade `pdfminer.six` from `20200517` to `20211012`; see [that library's changelog](https://github.com/pdfminer/pdfminer.six/blob/develop/CHANGELOG.md) for details, but a key difference is an improvement in how it assigns `line`, `rect`, and `curve` objects. (Diagonal two-point lines, for instance, are now `line` objects instead of `curve` objects.) ([#515](https://github.com/jsvine/pdfplumber/pull/515))
@@ -15,6 +16,7 @@ All notable changes to this project will be documented in this file. The format 
 - `.extract_text(...)` returns `""` instead of `None` when character list is empty. ([#482](https://github.com/jsvine/pdfplumber/issues/482) + [cb9900b](https://github.com/jsvine/pdfplumber/commit/cb9900b49706e96df520dbd1067c2a57a4cdb20d)) [h/t @tungph]
 - `.extract_words(...)` now includes `doctop` among the attributes it returns for each word. ([66fef89](https://github.com/jsvine/pdfplumber/commit/66fef89b670cf95d13a5e23040c7bf9339944c01))
 - Change behavior of horizontal `text_strategy`, so that it uses the top and bottom of *every* word, not just the top of every word and the bottom of the last. ([#467](https://github.com/jsvine/pdfplumber/pull/467) + [#466](https://github.com/jsvine/pdfplumber/issues/466) + [#265](https://github.com/jsvine/pdfplumber/issues/265)) [h/t @bobluda + @samkit-jain]
+- Change `table.merge_edges(...)` behavior when `join_tolerance` (and `x`/`y` variants) `<= 0`, so that joining is attempted regardless, to handle cases of overlapping lines.
 
 ### Fixed
 - Fix slowdown in `.extract_words(...)`/`WordExtractor.iter_chars_to_words(...)` on very long words, caused by repeatedly re-calculating bounding box. ([#483](https://github.com/jsvine/pdfplumber/discussions/483))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file. The format 
 - `.extract_words(...)` now includes `doctop` among the attributes it returns for each word. ([66fef89](https://github.com/jsvine/pdfplumber/commit/66fef89b670cf95d13a5e23040c7bf9339944c01))
 - Change behavior of horizontal `text_strategy`, so that it uses the top and bottom of *every* word, not just the top of every word and the bottom of the last. ([#467](https://github.com/jsvine/pdfplumber/pull/467) + [#466](https://github.com/jsvine/pdfplumber/issues/466) + [#265](https://github.com/jsvine/pdfplumber/issues/265)) [h/t @bobluda + @samkit-jain]
 - Change `table.merge_edges(...)` behavior when `join_tolerance` (and `x`/`y` variants) `<= 0`, so that joining is attempted regardless, to handle cases of overlapping lines.
+- Raise error if certain table-extraction settings are negative.
 
 ### Fixed
 - Fix slowdown in `.extract_words(...)`/`WordExtractor.iter_chars_to_words(...)` on very long words, caused by repeatedly re-calculating bounding box. ([#483](https://github.com/jsvine/pdfplumber/discussions/483))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. The format 
 - Add `.extract_text(layout=True)`, an *experimental feature* which attempts to mimic the structural layout of the text on the page. ([#10](https://github.com/jsvine/pdfplumber/issues/10))
 - Add `utils.merge_bboxes(bboxes)`, which returns the smallest bounding box that contains all bounding boxes in the `bboxes` argument. ([f8d5e70](https://github.com/jsvine/pdfplumber/commit/f8d5e70a509aa9ed3ee565d7d3f97bb5ec67f5a5))
 - Add `--precision` argument to CLI ([#520](https://github.com/jsvine/pdfplumber/pull/520))
+- Add `snap_x_tolerance` and `snap_y_tolerance` to table extraction settings. ([#51](https://github.com/jsvine/pdfplumber/pull/51) + [#475](https://github.com/jsvine/pdfplumber/issues/475)) [h/t @dustindall]
 
 ## Changed
 - Upgrade `pdfminer.six` from `20200517` to `20211012`; see [that library's changelog](https://github.com/pdfminer/pdfminer.six/blob/develop/CHANGELOG.md) for details, but a key difference is an improvement in how it assigns `line`, `rect`, and `curve` objects. (Diagonal two-point lines, for instance, are now `line` objects instead of `curve` objects.) ([#515](https://github.com/jsvine/pdfplumber/pull/515))

--- a/README.md
+++ b/README.md
@@ -313,6 +313,8 @@ By default, `extract_tables` uses the page's vertical and horizontal lines (or r
     "snap_x_tolerance": 3,
     "snap_y_tolerance": 3,
     "join_tolerance": 3,
+    "join_x_tolerance": 3,
+    "join_y_tolerance": 3,
     "edge_min_length": 3,
     "min_words_vertical": 3,
     "min_words_horizontal": 1,
@@ -333,7 +335,7 @@ By default, `extract_tables` uses the page's vertical and horizontal lines (or r
 |`"explicit_vertical_lines"`| A list of vertical lines that explicitly demarcate cells in the table. Can be used in combination with any of the strategies above. Items in the list should be either numbers — indicating the `x` coordinate of a line the full height of the page — or `line`/`rect`/`curve` objects.|
 |`"explicit_horizontal_lines"`| A list of horizontal lines that explicitly demarcate cells in the table. Can be used in combination with any of the strategies above. Items in the list should be either numbers — indicating the `y` coordinate of a line the full height of the page — or `line`/`rect`/`curve` objects.|
 |`"snap_tolerance"`, `"snap_x_tolerance"`, `"snap_y_tolerance"`| Parallel lines within `snap_tolerance` pixels will be "snapped" to the same horizontal or vertical position.|
-|`"join_tolerance"`| Line segments on the same infinite line, and whose ends are within `join_tolerance` of one another, will be "joined" into a single line segment.|
+|`"join_tolerance"`, `"join_x_tolerance"`, `"join_y_tolerance"`| Line segments on the same infinite line, and whose ends are within `join_tolerance` of one another, will be "joined" into a single line segment.|
 |`"edge_min_length"`| Edges shorter than `edge_min_length` will be discarded before attempting to reconstruct the table.|
 |`"min_words_vertical"`| When using `"vertical_strategy": "text"`, at least `min_words_vertical` words must share the same alignment.|
 |`"min_words_horizontal"`| When using `"horizontal_strategy": "text"`, at least `min_words_horizontal` words must share the same alignment.|

--- a/README.md
+++ b/README.md
@@ -310,6 +310,8 @@ By default, `extract_tables` uses the page's vertical and horizontal lines (or r
     "explicit_vertical_lines": [],
     "explicit_horizontal_lines": [],
     "snap_tolerance": 3,
+    "snap_x_tolerance": 3,
+    "snap_y_tolerance": 3,
     "join_tolerance": 3,
     "edge_min_length": 3,
     "min_words_vertical": 3,
@@ -330,7 +332,7 @@ By default, `extract_tables` uses the page's vertical and horizontal lines (or r
 |`"horizontal_strategy"`| Either `"lines"`, `"lines_strict"`, `"text"`, or `"explicit"`. See explanation below.|
 |`"explicit_vertical_lines"`| A list of vertical lines that explicitly demarcate cells in the table. Can be used in combination with any of the strategies above. Items in the list should be either numbers — indicating the `x` coordinate of a line the full height of the page — or `line`/`rect`/`curve` objects.|
 |`"explicit_horizontal_lines"`| A list of horizontal lines that explicitly demarcate cells in the table. Can be used in combination with any of the strategies above. Items in the list should be either numbers — indicating the `y` coordinate of a line the full height of the page — or `line`/`rect`/`curve` objects.|
-|`"snap_tolerance"`| Parallel lines within `snap_tolerance` pixels will be "snapped" to the same horizontal or vertical position.|
+|`"snap_tolerance"`, `"snap_x_tolerance"`, `"snap_y_tolerance"`| Parallel lines within `snap_tolerance` pixels will be "snapped" to the same horizontal or vertical position.|
 |`"join_tolerance"`| Line segments on the same infinite line, and whose ends are within `join_tolerance` of one another, will be "joined" into a single line segment.|
 |`"edge_min_length"`| Edges shorter than `edge_min_length` will be discarded before attempting to reconstruct the table.|
 |`"min_words_vertical"`| When using `"vertical_strategy": "text"`, at least `min_words_vertical` words must share the same alignment.|

--- a/pdfplumber/table.py
+++ b/pdfplumber/table.py
@@ -437,6 +437,24 @@ DEFAULT_TABLE_SETTINGS = {
     "intersection_y_tolerance": None,
 }
 
+NON_NEGATIVE_SETTINGS = [
+    "snap_tolerance",
+    "snap_x_tolerance",
+    "snap_y_tolerance",
+    "join_tolerance",
+    "join_x_tolerance",
+    "join_y_tolerance",
+    "edge_min_length",
+    "min_words_vertical",
+    "min_words_horizontal",
+    "text_tolerance",
+    "text_x_tolerance",
+    "text_y_tolerance",
+    "intersection_tolerance",
+    "intersection_x_tolerance",
+    "intersection_y_tolerance",
+]
+
 
 class TableFinder(object):
     """
@@ -480,6 +498,10 @@ class TableFinder(object):
         for k in table_settings.keys():
             if k not in DEFAULT_TABLE_SETTINGS:
                 raise ValueError(f"Unrecognized table setting: '{k}'")
+
+        for setting in NON_NEGATIVE_SETTINGS:
+            if (table_settings.get(setting) or 0) < 0:
+                raise ValueError(f"Table setting '{setting}' cannot be negative")
 
         resolved_table_settings = dict(DEFAULT_TABLE_SETTINGS)
         resolved_table_settings.update(table_settings)

--- a/tests/test_ca_warn_report.py
+++ b/tests/test_ca_warn_report.py
@@ -83,7 +83,11 @@ class Test(unittest.TestCase):
         assert (
             len(
                 table.merge_edges(
-                    p0.edges, snap_x_tolerance=3, snap_y_tolerance=3, join_tolerance=3
+                    p0.edges,
+                    snap_x_tolerance=3,
+                    snap_y_tolerance=3,
+                    join_x_tolerance=3,
+                    join_y_tolerance=3,
                 )
             )
             == 46
@@ -91,7 +95,23 @@ class Test(unittest.TestCase):
         assert (
             len(
                 table.merge_edges(
-                    p0.edges, snap_x_tolerance=0, snap_y_tolerance=3, join_tolerance=3
+                    p0.edges,
+                    snap_x_tolerance=3,
+                    snap_y_tolerance=3,
+                    join_x_tolerance=3,
+                    join_y_tolerance=0,
+                )
+            )
+            == 52
+        )
+        assert (
+            len(
+                table.merge_edges(
+                    p0.edges,
+                    snap_x_tolerance=0,
+                    snap_y_tolerance=3,
+                    join_x_tolerance=3,
+                    join_y_tolerance=3,
                 )
             )
             == 94
@@ -99,7 +119,11 @@ class Test(unittest.TestCase):
         assert (
             len(
                 table.merge_edges(
-                    p0.edges, snap_x_tolerance=3, snap_y_tolerance=0, join_tolerance=3
+                    p0.edges,
+                    snap_x_tolerance=3,
+                    snap_y_tolerance=0,
+                    join_x_tolerance=3,
+                    join_y_tolerance=3,
                 )
             )
             == 174
@@ -108,7 +132,11 @@ class Test(unittest.TestCase):
     def test_vertices(self):
         p0 = self.pdf.pages[0]
         edges = table.merge_edges(
-            p0.edges, snap_x_tolerance=3, snap_y_tolerance=3, join_tolerance=3
+            p0.edges,
+            snap_x_tolerance=3,
+            snap_y_tolerance=3,
+            join_x_tolerance=3,
+            join_y_tolerance=3,
         )
         ixs = table.edges_to_intersections(edges)
         assert len(ixs.keys()) == 304  # 38x8

--- a/tests/test_ca_warn_report.py
+++ b/tests/test_ca_warn_report.py
@@ -81,11 +81,34 @@ class Test(unittest.TestCase):
         p0 = self.pdf.pages[0]
         assert len(p0.edges) == 364
         assert (
-            len(table.merge_edges(p0.edges, snap_tolerance=3, join_tolerance=3)) == 46
+            len(
+                table.merge_edges(
+                    p0.edges, snap_x_tolerance=3, snap_y_tolerance=3, join_tolerance=3
+                )
+            )
+            == 46
+        )
+        assert (
+            len(
+                table.merge_edges(
+                    p0.edges, snap_x_tolerance=0, snap_y_tolerance=3, join_tolerance=3
+                )
+            )
+            == 94
+        )
+        assert (
+            len(
+                table.merge_edges(
+                    p0.edges, snap_x_tolerance=3, snap_y_tolerance=0, join_tolerance=3
+                )
+            )
+            == 174
         )
 
     def test_vertices(self):
         p0 = self.pdf.pages[0]
-        edges = table.merge_edges(p0.edges, snap_tolerance=3, join_tolerance=3)
+        edges = table.merge_edges(
+            p0.edges, snap_x_tolerance=3, snap_y_tolerance=3, join_tolerance=3
+        )
         ixs = table.edges_to_intersections(edges)
         assert len(ixs.keys()) == 304  # 38x8

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -44,6 +44,10 @@ class Test(unittest.TestCase):
                 },
             )
 
+        with pytest.raises(ValueError):
+            tf = table.TableFinder(self.pdf.pages[0], {"join_tolerance": -1})
+            tf.get_edges()
+
     def test_edges_strict(self):
         path = os.path.join(HERE, "pdfs/issue-140-example.pdf")
         with pdfplumber.open(path) as pdf:


### PR DESCRIPTION
Based largely on @dustindall's work in PR #51, adapted to current code. Also resolves issue #475.

This PR also changes `table.merge_edges(...)` behavior when `join_tolerance` (and `x`/`y` variants) `<= 0`, so that joining is attempted regardless, to handle cases of overlapping lines (which would still fulfill `tolerance == 0`). This is an uncommon situation but is, I believe, represents the user-expected behavior.