### PR TITLE
Make final changes for v0.6.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
       run: python -m black --check pdfplumber tests
 
     - name: Validate against isort
-      run: python isort --check-only pdfplumber tests
+      run: python -m isort --check-only pdfplumber tests
 
     - name: Validate against flake8
       run: python -m flake8 pdfplumber tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,9 @@ jobs:
     - name: Validate against psf/black
       run: python -m black --check pdfplumber tests
 
+    - name: Validate against isort
+      run: python isort --check-only pdfplumber tests
+
     - name: Validate against flake8
       run: python -m flake8 pdfplumber tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file. The format 
 - Add `utils.merge_bboxes(bboxes)`, which returns the smallest bounding box that contains all bounding boxes in the `bboxes` argument. ([f8d5e70](https://github.com/jsvine/pdfplumber/commit/f8d5e70a509aa9ed3ee565d7d3f97bb5ec67f5a5))
 - Add `--precision` argument to CLI ([#520](https://github.com/jsvine/pdfplumber/pull/520))
 - Add `snap_x_tolerance` and `snap_y_tolerance` to table extraction settings. ([#51](https://github.com/jsvine/pdfplumber/pull/51) + [#475](https://github.com/jsvine/pdfplumber/issues/475)) [h/t @dustindall]
-- Add `join_x_tolerance` and `join_y_tolerance` to table extraction settings.
+- Add `join_x_tolerance` and `join_y_tolerance` to table extraction settings. ([cbb34ce](https://github.com/jsvine/pdfplumber/commit/cbb34ce28b9b66d8d709304bbd0de267d82d75f3))
 
 ## Changed
 - Upgrade `pdfminer.six` from `20200517` to `20211012`; see [that library's changelog](https://github.com/pdfminer/pdfminer.six/blob/develop/CHANGELOG.md) for details, but a key difference is an improvement in how it assigns `line`, `rect`, and `curve` objects. (Diagonal two-point lines, for instance, are now `line` objects instead of `curve` objects.) ([#515](https://github.com/jsvine/pdfplumber/pull/515))
@@ -16,16 +16,22 @@ All notable changes to this project will be documented in this file. The format 
 - `.extract_text(...)` returns `""` instead of `None` when character list is empty. ([#482](https://github.com/jsvine/pdfplumber/issues/482) + [cb9900b](https://github.com/jsvine/pdfplumber/commit/cb9900b49706e96df520dbd1067c2a57a4cdb20d)) [h/t @tungph]
 - `.extract_words(...)` now includes `doctop` among the attributes it returns for each word. ([66fef89](https://github.com/jsvine/pdfplumber/commit/66fef89b670cf95d13a5e23040c7bf9339944c01))
 - Change behavior of horizontal `text_strategy`, so that it uses the top and bottom of *every* word, not just the top of every word and the bottom of the last. ([#467](https://github.com/jsvine/pdfplumber/pull/467) + [#466](https://github.com/jsvine/pdfplumber/issues/466) + [#265](https://github.com/jsvine/pdfplumber/issues/265)) [h/t @bobluda + @samkit-jain]
-- Change `table.merge_edges(...)` behavior when `join_tolerance` (and `x`/`y` variants) `<= 0`, so that joining is attempted regardless, to handle cases of overlapping lines.
-- Raise error if certain table-extraction settings are negative.
+- Change `table.merge_edges(...)` behavior when `join_tolerance` (and `x`/`y` variants) `<= 0`, so that joining is attempted regardless, to handle cases of overlapping lines. ([cbb34ce](https://github.com/jsvine/pdfplumber/commit/cbb34ce28b9b66d8d709304bbd0de267d82d75f3))
+- Raise error if certain table-extraction settings are negative. ([aa2d594](https://github.com/jsvine/pdfplumber/commit/aa2d594d3b3352dbcef503e4df2e045d69fc2511))
 
 ### Fixed
 - Fix slowdown in `.extract_words(...)`/`WordExtractor.iter_chars_to_words(...)` on very long words, caused by repeatedly re-calculating bounding box. ([#483](https://github.com/jsvine/pdfplumber/discussions/483))
 - Handle `UnicodeDecodeError` when trying to decode utf-16-encoded annotations ([#463](https://github.com/jsvine/pdfplumber/issues/463)) [h/t @tungph]
 - Fix crash when extracting tables with null values in `(text|intersection)_(x|y)_tolerance` settings. ([#539](https://github.com/jsvine/pdfplumber/discussions/539)) [h/t @yoavxyoav]
 
+### Removed
+- Remove `pdfplumber.load(...)` method, which has been deprecated since `0.5.23` ([54cbbc5](https://github.com/jsvine/pdfplumber/commit/54cbbc5321b42f3976b2ac750c25b7b2ec6045d7))
+
 ### Development Changes
 - Add `CONTRIBUTING.md` ([#428](https://github.com/jsvine/pdfplumber/pull/428))
+- Enforce import order via [`isort`](https://pycqa.github.io/isort/index.html) ([d72b879](https://github.com/jsvine/pdfplumber/commit/d72b879665b410bd0f9c436d54ae60b3989489d5))
+- Update Pillow and Wand versions in `requirements.txt` ([cae6924](https://github.com/jsvine/pdfplumber/commit/cae69246c53e49f95c1adbb5dffb3d49e726c5df))
+- Update all dependency versions in `requirements-dev.txt` ([2f7e7ee](https://github.com/jsvine/pdfplumber/commit/2f7e7ee49172d681f34269a0db0276dffefa6386))
 
 ## [0.5.28] — 2021-05-08
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,6 @@ Thank you for your interest in `pdfplumber`! Before submitting an issue or filin
 - If you would like to propose a change that is more __complex__ than a simple bug-fix, please [first open a discussion](https://github.com/jsvine/pdfplumber/discussions). If you are submitting a __simple__ bugfix, typo correction, et cetera, feel free to open a pull request directly.
 - PRs should be submitted against the __`develop` branch__ only.
 - PRs should contain one or more __tests__ that support the changes. The tests should pass with the new code but fail on the commits prior. For guidance, see the existing tests in the `tests/` directory. To execute the tests, run `make tests` or `python -m pytest`.
-- Python code in PRs should conform to [`psf/black`](https://black.readthedocs.io/en/stable/) and [`flake8`](https://pypi.org/project/flake8/) __formatting__ guidelines. To test this, run `make lint`. To reformat your code, run `make format`.
+- Python code in PRs should conform to [`psf/black`](https://black.readthedocs.io/en/stable/), [`isort`](https://pycqa.github.io/isort/index.html), and [`flake8`](https://pypi.org/project/flake8/) __formatting__ guidelines. To automatically reformat your code accordingly, run `make format`. To test the formatting and `flake8` compliance, run `make lint`.
 - Please add yourself to the [list of contributors](https://github.com/jsvine/pdfplumber#acknowledgments--contributors).
 - Please also update the [CHANGELOG.md](https://github.com/jsvine/pdfplumber/blob/develop/CHANGELOG.md).

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,14 @@ tests:
 check-black:
 	${PYTHON} -m black --check pdfplumber tests
 
+check-isort:
+	${PYTHON} -m isort --check-only pdfplumber tests
+
 check-flake:
 	${PYTHON} -m flake8 pdfplumber tests
 
-lint: check-flake check-black
+lint: check-flake check-black check-isort
 
 format:
 	${PYTHON} -m black pdfplumber tests
+	${PYTHON} -m isort pdfplumber tests

--- a/pdfplumber/__init__.py
+++ b/pdfplumber/__init__.py
@@ -6,8 +6,6 @@ __all__ = [
     "set_debug",
 ]
 
-import sys
-
 import pdfminer
 import pdfminer.pdftypes
 
@@ -19,15 +17,6 @@ pdfminer.pdftypes.STRICT = False
 pdfminer.pdfinterp.STRICT = False
 
 open = PDF.open
-
-
-def load(file_or_buffer, **kwargs):
-    sys.stderr.write(
-        "Warning: pdfplumber.load is deprecated."
-        "Please use pdfplumber.open (with same arguments) instead."
-        "\n"
-    )
-    return PDF(file_or_buffer, **kwargs)
 
 
 def set_debug(debug=0):

--- a/pdfplumber/__init__.py
+++ b/pdfplumber/__init__.py
@@ -6,12 +6,14 @@ __all__ = [
     "set_debug",
 ]
 
-from ._version import __version__
-from .pdf import PDF
-from . import utils
+import sys
+
 import pdfminer
 import pdfminer.pdftypes
-import sys
+
+from . import utils
+from ._version import __version__
+from .pdf import PDF
 
 pdfminer.pdftypes.STRICT = False
 pdfminer.pdfinterp.STRICT = False

--- a/pdfplumber/_version.py
+++ b/pdfplumber/_version.py
@@ -1,2 +1,2 @@
-version_info = (0, 5, 28)
+version_info = (0, 6, 0)
 __version__ = ".".join(map(str, version_info))

--- a/pdfplumber/cli.py
+++ b/pdfplumber/cli.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
-from . import convert
-from .pdf import PDF
 import argparse
-from itertools import chain
 import json
 import sys
+from itertools import chain
+
+from . import convert
+from .pdf import PDF
 
 
 def parse_page_spec(p_str):

--- a/pdfplumber/container.py
+++ b/pdfplumber/container.py
@@ -1,5 +1,6 @@
 from itertools import chain
-from . import utils, convert
+
+from . import convert, utils
 
 
 class Container(object):

--- a/pdfplumber/convert.py
+++ b/pdfplumber/convert.py
@@ -1,8 +1,9 @@
-from .utils import decode_text
-import json
-import csv
 import base64
+import csv
+import json
 from io import StringIO
+
+from .utils import decode_text
 
 COLS_TO_PREPEND = [
     "object_type",

--- a/pdfplumber/display.py
+++ b/pdfplumber/display.py
@@ -1,10 +1,11 @@
-from . import utils
-from .table import TableFinder
+from io import BytesIO
 
 import PIL.Image
 import PIL.ImageDraw
 import wand.image
-from io import BytesIO
+
+from . import utils
+from .table import TableFinder
 
 
 class COLORS(object):

--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -1,10 +1,12 @@
-from . import utils
-from .utils import resolve_all
-from .table import TableFinder
-from .container import Container
-from pdfminer.pdfinterp import PDFPageInterpreter
-from pdfminer.converter import PDFPageAggregator
 import re
+
+from pdfminer.converter import PDFPageAggregator
+from pdfminer.pdfinterp import PDFPageInterpreter
+
+from . import utils
+from .container import Container
+from .table import TableFinder
+from .utils import resolve_all
 
 lt_pat = re.compile(r"^LT")
 
@@ -286,7 +288,7 @@ class Page(Container):
         For conversion_kwargs, see:
         http://docs.wand-py.org/en/latest/wand/image.html#wand.image.Image
         """
-        from .display import PageImage, DEFAULT_RESOLUTION
+        from .display import DEFAULT_RESOLUTION, PageImage
 
         kwargs = dict(conversion_kwargs)
         if "resolution" not in conversion_kwargs:

--- a/pdfplumber/pdf.py
+++ b/pdfplumber/pdf.py
@@ -1,15 +1,16 @@
+import itertools
+import logging
+import pathlib
+
+from pdfminer.layout import LAParams
+from pdfminer.pdfdocument import PDFDocument
+from pdfminer.pdfinterp import PDFResourceManager
+from pdfminer.pdfpage import PDFPage
+from pdfminer.pdfparser import PDFParser
+
 from .container import Container
 from .page import Page
 from .utils import resolve_and_decode
-
-import logging
-import pathlib
-import itertools
-from pdfminer.pdfparser import PDFParser
-from pdfminer.pdfdocument import PDFDocument
-from pdfminer.pdfpage import PDFPage
-from pdfminer.pdfinterp import PDFResourceManager
-from pdfminer.layout import LAParams
 
 logger = logging.getLogger(__name__)
 

--- a/pdfplumber/table.py
+++ b/pdfplumber/table.py
@@ -1,6 +1,7 @@
-from . import utils
-from operator import itemgetter
 import itertools
+from operator import itemgetter
+
+from . import utils
 
 DEFAULT_SNAP_TOLERANCE = 3
 DEFAULT_JOIN_TOLERANCE = 3

--- a/pdfplumber/utils.py
+++ b/pdfplumber/utils.py
@@ -1,8 +1,9 @@
-from pdfminer.utils import PDFDocEncoding
-from pdfminer.psparser import PSLiteral
-from pdfminer.pdftypes import PDFObjRef
-from operator import itemgetter
 import itertools
+from operator import itemgetter
+
+from pdfminer.pdftypes import PDFObjRef
+from pdfminer.psparser import PSLiteral
+from pdfminer.utils import PDFDocEncoding
 
 DEFAULT_X_TOLERANCE = 3
 DEFAULT_Y_TOLERANCE = 3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ pytest-cov==3.0.0
 pytest-parallel==0.1.1
 flake8==4.0.1
 black==21.12b0
+isort==5.10.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
-pytest==6.1.2
-pytest-cov==2.10.1
-pytest-parallel==0.1.0
-flake8==3.8.3
-black==20.8b0
+pytest==6.2.5
+pytest-cov==3.0.0
+pytest-parallel==0.1.1
+flake8==4.0.1
+black==21.12b0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pdfminer.six==20211012
-Pillow>=7.0.0
-Wand
+Pillow>=8.4
+Wand>=0.6.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,9 @@ ignore =
 [tool:pytest]
 addopts=--cov=pdfplumber --cov-report xml:coverage.xml --cov-report term
 
+[tool.isort]
+profile = "black"
+
 [tox]
 envlist = py35,py36,py37,py38
 toxworkdir={env:TOX_WORK_DIR:.tox}

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
-import unittest
-import pytest
-import pdfplumber
-import os
-
 import logging
+import os
+import unittest
+
+import pytest
+
+import pdfplumber
 
 logging.disable(logging.ERROR)
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -165,8 +165,3 @@ class Test(unittest.TestCase):
             with pdfplumber.open(f) as pdf:
                 assert len(pdf.metadata)
             assert not f.closed
-
-        # Will be removed from library soon
-        with open(path, "rb") as f:
-            with pdfplumber.load(f) as pdf:
-                assert len(pdf.metadata)

--- a/tests/test_ca_warn_report.py
+++ b/tests/test_ca_warn_report.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
-import unittest
-import pdfplumber
-from pdfplumber import utils
-from pdfplumber import table
-import os
-
 import logging
+import os
+import unittest
+
+import pdfplumber
+from pdfplumber import table, utils
 
 logging.disable(logging.ERROR)
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
-import unittest
-import pdfplumber
-from subprocess import Popen, PIPE
-from io import StringIO
 import json
-import sys
-import os
-
 import logging
+import os
+import sys
+import unittest
+from io import StringIO
+from subprocess import PIPE, Popen
+
+import pdfplumber
 
 logging.disable(logging.ERROR)
 

--- a/tests/test_dedupe_chars.py
+++ b/tests/test_dedupe_chars.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-import unittest
-import os
 import logging
+import os
+import unittest
 
 import pdfplumber
-
 
 logging.disable(logging.ERROR)
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
-import unittest
-import pdfplumber
-import os
 import io
-
 import logging
+import os
+import unittest
+
+import pdfplumber
 
 logging.disable(logging.ERROR)
 

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
-import unittest
-import pdfplumber
-import os
-
 import logging
+import os
+import unittest
+
+import pdfplumber
 
 logging.disable(logging.ERROR)
 

--- a/tests/test_laparams.py
+++ b/tests/test_laparams.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
-import unittest
-import pdfplumber
-import os
-
 import logging
+import os
+import unittest
+
+import pdfplumber
 
 logging.disable(logging.ERROR)
 

--- a/tests/test_list_metadata.py
+++ b/tests/test_list_metadata.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
-import unittest
-import pdfplumber
-import os
-
 import logging
+import os
+import unittest
+
+import pdfplumber
 
 logging.disable(logging.ERROR)
 

--- a/tests/test_nics_report.py
+++ b/tests/test_nics_report.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
-import unittest
-import pdfplumber
-from operator import itemgetter
-from pdfplumber.utils import within_bbox, collate_chars
-import os
-
 import logging
+import os
+import unittest
+from operator import itemgetter
+
+import pdfplumber
+from pdfplumber.utils import collate_chars, within_bbox
 
 logging.disable(logging.ERROR)
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
+import logging
+import os
 import unittest
+
 import pytest
+
 import pdfplumber
 from pdfplumber import table
-import os
-
-import logging
 
 logging.disable(logging.ERROR)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python
+import logging
+import os
 import unittest
-import pytest
-import pdfplumber
-from pdfplumber import utils
-from pdfminer.pdfparser import PDFObjRef
-from pdfminer.psparser import PSLiteral
 from itertools import groupby
 from operator import itemgetter
-import os
 
-import logging
+import pytest
+from pdfminer.pdfparser import PDFObjRef
+from pdfminer.psparser import PSLiteral
+
+import pdfplumber
+from pdfplumber import utils
 
 logging.disable(logging.ERROR)
 


### PR DESCRIPTION
See commits below. In short:

- Updates dependencies
- Adds `isort` linting/formatting
- Removes deprecated `.load(...)` method