### PR TITLE
addressing issue #578

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ Many thanks to the following users who've contributed ideas, features, and fixes
 - [Daniel Peña](https://github.com/trifling)
 - [bobluda](https://github.com/bobluda)
 - [@ramcdona](https://github.com/ramcdona)
-
+- [augeos-grosso](https://github.com/augeos-grosso) aka [johnhuge](https://github.com/johnhuge)
 ## Contributing
 
 Pull requests are welcome, but please submit a proposal issue first, as the library is in active development.

--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ Many thanks to the following users who've contributed ideas, features, and fixes
 - [Daniel Peña](https://github.com/trifling)
 - [bobluda](https://github.com/bobluda)
 - [@ramcdona](https://github.com/ramcdona)
-- [augeos-grosso](https://github.com/augeos-grosso) aka [johnhuge](https://github.com/johnhuge)
+- [johnhuge](https://github.com/johnhuge)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ Many thanks to the following users who've contributed ideas, features, and fixes
 - [bobluda](https://github.com/bobluda)
 - [@ramcdona](https://github.com/ramcdona)
 - [augeos-grosso](https://github.com/augeos-grosso) aka [johnhuge](https://github.com/johnhuge)
+
 ## Contributing
 
 Pull requests are welcome, but please submit a proposal issue first, as the library is in active development.

--- a/pdfplumber/pdf.py
+++ b/pdfplumber/pdf.py
@@ -7,6 +7,7 @@ from pdfminer.pdfdocument import PDFDocument
 from pdfminer.pdfinterp import PDFResourceManager
 from pdfminer.pdfpage import PDFPage
 from pdfminer.pdfparser import PDFParser
+from pdfminer.psparser import PSException
 
 from .container import Container
 from .page import Page
@@ -52,7 +53,11 @@ class PDF(Container):
     def open(cls, path_or_fp, **kwargs):
         if isinstance(path_or_fp, (str, pathlib.Path)):
             fp = open(path_or_fp, "rb")
-            inst = cls(fp, **kwargs)
+            try:
+                inst = cls(fp, **kwargs)
+            except PSException:
+                fp.close()
+                raise
             inst.close_file = fp.close
             return inst
         else:


### PR DESCRIPTION
This PR fixes #578 .
Indeed the line causing the missed close() call on Windows (and only on Windows it seems) was the one @samkit-jain pointed out.

The original exception was ```pdfminer.pdfparser.PDFSyntaxError```, but i figured it would be best using ```pdfminer.psparser.PSException```, since it is the most general exception i could find that made sense using.