### PR TITLE
Add py.typed marker for PEP 561 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file. The format 
 - Add `pdfplumber.ctm` submodule with class `CTM`, to calculate scale, skew, and translation of a current transformation matrix obtained from a `char`'s `"matrix"` property.
 - Add `page.search(...)`, an *experimental feature* that allows you to search a page's text via regular expressions and non-regex strings, returning the text, any regex matches, the bounding box coordinates, and the char objects themselves. ([#201](https://github.com/jsvine/pdfplumber/issues/201))
 - Add `--include-attrs`/`--exclude-attrs` to CLI (and corresponding params to `.to_json(...)`, `.to_csv(...)`, and `Serializer`.
+- Add `py.typed` for PEP561 compatibility and detection of typing hints by mypy.
 
 ### Removed
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE.txt
 include README.md
+include pdfplumber/py.typed

--- a/setup.py
+++ b/setup.py
@@ -52,5 +52,5 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
-    package_data={"pdfplumber": "py.typed"}
+    package_data={"pdfplumber": ["py.typed"]}
 )

--- a/setup.py
+++ b/setup.py
@@ -52,5 +52,4 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
-    package_data={"pdfplumber": ["py.typed"]}
 )

--- a/setup.py
+++ b/setup.py
@@ -52,4 +52,5 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
+    package_data={"pdfplumber": "py.typed"}
 )


### PR DESCRIPTION
Although type hints have been introduced on the previous release (thank you very much for that! :pray:), `mypy` does not detect the type hints when the package is installed since it is missing stubs or a `py.typed` marker:

```console
src/my_package/myfile.py:4: error: Skipping analyzing "pdfplumber": module is installed, but missing library stubs or py.typed marker
```
I propose adding an empty `py.typed` file, which should be enough for `mypy` to detect that `pdfplumber` is typed, and adding this file to the setup's `package_data`. This should make `pdfplumber` PEP 561 compatible.