### PR TITLE
Handle `ValueError` exception when searching for text using regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## Unreleased
+
+### Fixed
+
+- Fix `ValueError` exception when using `page.search(regex=True)`. ([#683](https://github.com/jsvine/pdfplumber/issues/683)
+
 ## [0.7.1] - 2022-05-31
 
 ### Fixed

--- a/pdfplumber/utils.py
+++ b/pdfplumber/utils.py
@@ -496,7 +496,10 @@ class TextLayout:
         def match_to_dict(m: Match[str]) -> Dict[str, Any]:
             subset = self.layout_tuples[m.start() : m.end()]
             chars = [c for (text, c) in subset if c is not None]
-            x0, top, x1, bottom = objects_to_bbox(chars)
+            try:
+                x0, top, x1, bottom = objects_to_bbox(chars)
+            except ValueError:
+                x0, top, x1, bottom = None, None, None, None
             return {
                 "text": m.group(0),
                 "groups": m.groups(),

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -198,3 +198,12 @@ class Test(unittest.TestCase):
         with pdfplumber.open(path) as pdf:
             annots = pdf.annots
             annots[0]["contents"] == "日本語"
+
+    def test_issue_683(self):
+        """
+        Page.search ValueError: min() arg is an empty sequence
+        """
+        path = os.path.join(HERE, "pdfs/issue-71-duplicate-chars-2.pdf")
+        with pdfplumber.open(path) as pdf:
+            page = pdf.pages[0]
+            page.search(r"\d+", regex=True)


### PR DESCRIPTION
This PR attempts to fix the issue #683 reported by @bpugnaire. The issue was happening because 
```python
chars = [c for (text, c) in subset if c is not None]
```
would return an empty array because of which the subsequent
```python
x0, top, x1, bottom = objects_to_bbox(chars)
```
call would throw a `ValueError` exception.

I was able to reproduce the issue on the file [issue-71-duplicate-chars-2.pdf](https://github.com/jsvine/pdfplumber/blob/develop/tests/pdfs/issue-71-duplicate-chars-2.pdf) using the regex `\d+`. The solution implied is a simple one with `try-except` handling. However, I am unsure if this is the correct solution because it would result in the output having objects with `x0`, `x1`, ... being null which may cause further processing issues as they are expected to be numbers. Another solution would be to not include these objects in the final answer but that may result in incomplete data being returned. Yet to debug why this issue happened in the first place, that is, a solution that would result in the `chars` list not being empty.