### PR TITLE
Mypy compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Unreleased]
+
+## Fixed
+
+- `py.typed` file not included in Pypi distribution. Fixed with adding mypy compatibility.
+
 ## [0.7.4] - 2022-07-19
 
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,9 @@ setup(
             "test",
         ]
     ),
+    include_package_data=True,
+    package_data={"pdfplumber": ["py.typed"]},
+    zip_safe=False,
     tests_require=base_reqs + dev_reqs,
     python_requires=">=3.7",
     install_requires=base_reqs,


### PR DESCRIPTION
Add `py.typed` to package data to ensure that it is included when building. Include `zip_safe=False` per `mypy`'s instructions. See #698.