### PR TITLE
fix: calculate rotation using 0 when Rotate is None

### DIFF
--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -90,7 +90,7 @@ class Page(Container):
         self.root_page = self
         self.page_obj = page_obj
         self.page_number = page_number
-        _rotation = resolve_all(self.page_obj.attrs.get("Rotate", 0))
+        _rotation = resolve_all(self.page_obj.attrs.get("Rotate", 0)) or 0
         self.rotation = _rotation % 360
         self.page_obj.rotate = self.rotation
         self.initial_doctop = initial_doctop


### PR DESCRIPTION
An error occurred when calculating rotation when Rotate was None.
Fixed to calculate rotation using 0 when Rotate is None.

```
TypeError: unsupported operand type(s) for %: 'NoneType' and 'int'

self.rotation = _rotation % 360
File "/var/task/pdfplumber/page.py", line 54, in __init__
```