### PR TITLE
update form-parsing example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,10 +461,10 @@ for field in fields:
 Once you run this script, `form_data` is a list containing a three-element tuple for each form element. For instance, a PDF form with a city and state field might look like this.
 ```
 [
- [b'STATE.0', b'enter STATE', b'CA'],
- [b'section 2  accident infoRmation.1.0',
-  b'enter city of accident',
-  b'SAN FRANCISCO']
+ ['STATE.0', 'enter STATE', 'CA'],
+ ['section 2  accident infoRmation.1.0',
+  'enter city of accident',
+  'SAN FRANCISCO']
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ def parse_field_helper(form_data, field, prefix=None):
 
 
 form_data = []
-
+fields = pdf.doc.catalog["AcroForm"].resolve()["Fields"]
 for field in fields:
     parse_field_helper(form_data, field)
 ```

--- a/README.md
+++ b/README.md
@@ -429,7 +429,8 @@ Sometimes PDF files can contain forms that include inputs that people can fill o
 For example, this snippet will retrieve form field names and values and store them in a dictionary.
 
 ```python
-from pdfplumber.utils.pdfinternals import resolve_and_decode
+import pdfplumber
+from pdfplumber.utils.pdfinternals import resolve_and_decode, resolve
 
 pdf = pdfplumber.open("document_with_form.pdf")
 
@@ -453,7 +454,7 @@ def parse_field_helper(form_data, field, prefix=None):
 
 
 form_data = []
-fields = pdf.doc.catalog["AcroForm"].resolve()["Fields"]
+fields = resolve(pdf.doc.catalog["AcroForm"])["Fields"]
 for field in fields:
     parse_field_helper(form_data, field)
 ```

--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ def parse_field_helper(form_data, field, prefix=None):
         prepended to the child's field name.
     """
     resolved_field = field.resolve()
-    field_name = b'.'.join(filter(lambda x: x, [prefix, resolved_field.get("T")]))
+    field_name = b'.'.join([prefix, resolved_field.get("T")]) if prefix and resolved_field.get("T") else resolved_field.get("T")
     if "Kids" in resolved_field:
         for kid_field in resolved_field["Kids"]:
             parse_field_helper(form_data, kid_field, prefix=field_name)

--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ Sometimes PDF files can contain forms that include inputs that people can fill o
 
 `pdfplumber` doesn't have an interface for working with form data, but you can access it using `pdfplumber`'s wrappers around `pdfminer`.
 
-For example, this snippet will retrieve form field names and values and store them in a dictionary. You may have to modify this script to handle cases like nested fields (see page 676 of the specification).
+For example, this snippet will retrieve form field names and values and store them in a dictionary.
 
 ```python
 pdf = pdfplumber.open("document_with_form.pdf")

--- a/README.md
+++ b/README.md
@@ -458,6 +458,15 @@ for field in fields:
     parse_field_helper(form_data, field)
 ```
 
+Once you run this script, `form_data` is a list containing a three-element tuple for each form element. For instance, a PDF form with a city and state field might look like this.
+```
+[
+ [b'STATE.0', b'enter STATE', b'CA'],
+ [b'section 2  accident infoRmation.1.0',
+  b'enter city of accident',
+  b'SAN FRANCISCO']
+]
+```
 
 ## Demonstrations
 


### PR DESCRIPTION
This form-parsing example handles form fields recursively contained within other form fields, removes the incorrect-assumption that field-names are unique and includes the alternate field name in output (which is often a very useful guide to what's in a field).

the prior form-parsing example used the field-name ("T" entry) as the key in the form_data dict, implicitly assuming that the field name is globally unique within a document. That's not a correct assumption; nested field names are often simply a numeric index like 1 or 0. (Nested fields were previously ignored.)

The prior example also entirely ignored the TU entry alternate field name.