### PR TITLE
Explicitly close `pypdfium2.PdfDocument` in `get_page_image`

### DIFF
--- a/pdfplumber/display.py
+++ b/pdfplumber/display.py
@@ -53,10 +53,8 @@ def get_page_image(
         stream.seek(0)
         src = stream
 
-    pdfium_page = pypdfium2.PdfDocument(
-        src,
-        password=password,
-    ).get_page(page_ix)
+    pdfium_doc = pypdfium2.PdfDocument(src, password=password)
+    pdfium_page = pdfium_doc.get_page(page_ix)
 
     img: PIL.Image.Image = pdfium_page.render(
         # Modifiable arguments
@@ -67,6 +65,9 @@ def get_page_image(
         # Non-modifiable arguments
         prefer_bgrx=True,
     ).to_pil()
+    # In theory `autoclose` when creating it should make it close...
+    # automatically.  In practice this does not seem to be the case.
+    pdfium_doc.close()
 
     return img.convert("RGB")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -55,7 +55,7 @@ class Test(unittest.TestCase):
 
     def test_resolve_all(self):
         info = self.pdf.doc.xrefs[0].trailer["Info"]
-        assert type(info) == PDFObjRef
+        assert type(info) is PDFObjRef
         a = [{"info": info}]
         a_res = utils.resolve_all(a)
         assert a_res[0]["info"]["Producer"] == self.pdf.doc.info[0]["Producer"]


### PR DESCRIPTION
Fixes #1089 