### PR TITLE
Handle missing ParentTree

### DIFF
--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -4,6 +4,8 @@ import os
 import unittest
 from collections import deque
 
+from pdfminer.pdftypes import resolve1
+
 import pdfplumber
 from pdfplumber.structure import PDFStructTree
 
@@ -593,6 +595,7 @@ PVSTRUCT2 = [
     }
 ]
 
+
 IMAGESTRUCT = [
     {
         "type": "Document",
@@ -893,6 +896,14 @@ class TestMany(unittest.TestCase):
         assert pdf.structure_tree == PVSTRUCT
         page = pdf.pages[1]
         assert page.structure_tree == PVSTRUCT1
+
+    def test_missing_parenttree(self):
+        """Verify we can get structure without a ParentTree."""
+        path = os.path.join(HERE, "pdfs/2023-06-20-PV.pdf")
+        pdf = pdfplumber.open(path)
+        root = resolve1(pdf.doc.catalog["StructTreeRoot"])
+        del root["ParentTree"]
+        assert pdf.pages[1].structure_tree == PVSTRUCT1
 
     def test_image_structure(self):
         path = os.path.join(HERE, "pdfs/image_structure.pdf")


### PR DESCRIPTION
It's not supposed to happen according to section 14.7.4.4 of the PDF 1.7 standard:

> The parent tree is a number tree (see 7.9.7, “Number Trees”), accessed from the ParentTree entry in a
document’s structure tree root (Table 322). The tree shall contain an entry for each object that is a content item
of at least one structure element and for each content stream containing at least one marked-content sequence
that is a content item. The key for each entry shall be an integer given as the value of the StructParent or
StructParents entry in the object (see Table 326)

But of course it does, for example in https://assets-global.website-files.com/5e691d0b7de02f1fd6919876/65b7f08c45d632b34f027ec9_Mines%20Against%20Humanity%20EN.pdf

Handle this gracefully with the "unparsed pages" mechanism.