### PR TITLE
Some utility methods for logical structure

### DIFF
--- a/docs/structure.md
+++ b/docs/structure.md
@@ -59,3 +59,18 @@ In this case, because marked content IDs are specific to a given page,
 each element will also have a `page_number` attribute, which is the
 number of the page containing (partially or completely) this element,
 indexed from 1 (for consistency with `pdfplumber.Page`).
+
+You can also access the underlying `PDFStructTree` object for more
+flexibility, including visual debugging.  For instance to plot the
+bounding boxes of the contents of all of the `TD` elements on the
+first page of a document:
+
+    page = pdf.pages[0]
+    stree = PDFStructTree(pdf, page)
+    img = page.to_image()
+    img.draw_rects(stree.element_bbox(td) for td in table.find_all("TD"))
+
+The `find_all` method works rather like the same method in
+[BeautifulSoup](https://beautiful-soup-4.readthedocs.io/en/latest/#searching-the-tree) -
+it takes an element name, a regular expression, or a matching
+function.

--- a/pdfplumber/structure.py
+++ b/pdfplumber/structure.py
@@ -53,7 +53,7 @@ class PDFStructElement:
     def __iter__(self) -> Iterator["PDFStructElement"]:
         return iter(self.children)
 
-    def all_mcids(self) -> Iterator[tuple[Optional[int], int]]:
+    def all_mcids(self) -> Iterator[Tuple[Optional[int], int]]:
         """Collect all MCIDs (with their page numbers, if there are
         multiple pages in the tree) inside a structure element.
         """

--- a/pdfplumber/structure.py
+++ b/pdfplumber/structure.py
@@ -69,6 +69,7 @@ def _find_all(
 class Findable:
     """find() and find_all() methods that can be inherited to avoid
     repeating oneself"""
+
     children: List["PDFStructElement"]
 
     def find_all(
@@ -469,7 +470,7 @@ class PDFStructTree(Findable):
             page = self.pages[el.page_number]
         bbox = el.attributes.get("BBox", None)
         if page is not None and bbox is not None:
-            from .page import _invert_box, _normalize_box, CroppedPage
+            from .page import CroppedPage, _invert_box, _normalize_box
 
             # Use secret knowledge of CroppedPage (cannot use
             # page.height because it is the *cropped* dimension, but

--- a/pdfplumber/structure.py
+++ b/pdfplumber/structure.py
@@ -92,10 +92,15 @@ def _findall(
     elements: Iterable[PDFStructElement],
     matcher: str | Pattern[str] | Callable[[PDFStructElement], bool],
 ) -> Iterator[PDFStructElement]:
+    """
+    Common code for `findall()` in trees and elements.
+    """
     def match_tag(x: PDFStructElement) -> bool:
+        """Match an element name."""
         return x.type == matcher
 
     def match_regex(x: PDFStructElement) -> bool:
+        """Match an element name by regular expression."""
         return matcher.match(x.type)  # type: ignore
 
     if isinstance(matcher, str):

--- a/pdfplumber/structure.py
+++ b/pdfplumber/structure.py
@@ -14,6 +14,7 @@ from typing import (
     Optional,
     Pattern,
     Tuple,
+    Union,
 )
 
 from pdfminer.data_structures import NumberTree
@@ -30,6 +31,9 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:  # pragma: nocover
     from .page import Page
     from .pdf import PDF
+
+
+MatchFunc = Callable[["PDFStructElement"], bool]
 
 
 @dataclass
@@ -64,7 +68,7 @@ class PDFStructElement:
             d.extendleft(reversed(el.children))
 
     def find_all(
-        self, matcher: str | Pattern[str] | Callable[["PDFStructElement"], bool]
+        self, matcher: Union[str, Pattern[str], MatchFunc]
     ) -> Iterator["PDFStructElement"]:
         """Iterate depth-first over matching elements in subtree.
 
@@ -91,7 +95,7 @@ class PDFStructElement:
 
 def _find_all(
     elements: Iterable[PDFStructElement],
-    matcher: str | Pattern[str] | Callable[[PDFStructElement], bool],
+    matcher: Union[str, Pattern[str], MatchFunc],
 ) -> Iterator[PDFStructElement]:
     """
     Common code for `find_all()` in trees and elements.
@@ -437,7 +441,7 @@ class PDFStructTree:
         return iter(self.children)
 
     def find_all(
-        self, matcher: str | Pattern[str] | Callable[["PDFStructElement"], bool]
+        self, matcher: Union[str, Pattern[str], MatchFunc]
     ) -> Iterator[PDFStructElement]:
         """
         Iterate depth-first over all matching elements in subtree.

--- a/pdfplumber/utils/geometry.py
+++ b/pdfplumber/utils/geometry.py
@@ -84,7 +84,8 @@ def clip_obj(obj: T_obj, bbox: T_bbox) -> Optional[T_obj]:
         copy[attr] = dims[attr]
 
     diff = dims["top"] - obj["top"]
-    copy["doctop"] = obj["doctop"] + diff
+    if "doctop" in copy:
+        copy["doctop"] = obj["doctop"] + diff
     copy["width"] = copy["x1"] - copy["x0"]
     copy["height"] = copy["bottom"] - copy["top"]
 

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -864,38 +864,38 @@ class TestClass(unittest.TestCase):
         doc_elem = next(iter(stree))
         assert [k.type for k in doc_elem] == ["P", "P", "Figure"]
 
-    def test_findall_tree(self):
+    def test_find_all_tree(self):
         """
-        Test findall() on trees
+        Test find_all() on trees
         """
         path = os.path.join(HERE, "pdfs/image_structure.pdf")
         pdf = pdfplumber.open(path)
         stree = PDFStructTree(pdf, pdf.pages[0])
-        figs = list(stree.findall("Figure"))
+        figs = list(stree.find_all("Figure"))
         assert len(figs) == 1
-        figs = list(stree.findall(re.compile(r"Fig.*")))
+        figs = list(stree.find_all(re.compile(r"Fig.*")))
         assert len(figs) == 1
-        figs = list(stree.findall(lambda x: x.type == "Figure"))
+        figs = list(stree.find_all(lambda x: x.type == "Figure"))
         assert len(figs) == 1
-        figs = list(stree.findall("Foogure"))
+        figs = list(stree.find_all("Foogure"))
         assert len(figs) == 0
-        figs = list(stree.findall(re.compile(r"Fog.*")))
+        figs = list(stree.find_all(re.compile(r"Fog.*")))
         assert len(figs) == 0
-        figs = list(stree.findall(lambda x: x.type == "Flogger"))
+        figs = list(stree.find_all(lambda x: x.type == "Flogger"))
         assert len(figs) == 0
 
-    def test_findall_element(self):
+    def test_find_all_element(self):
         """
-        Test findall() on elements
+        Test find_all() on elements
         """
         path = os.path.join(HERE, "pdfs/pdf_structure.pdf")
         pdf = pdfplumber.open(path)
         stree = PDFStructTree(pdf)
-        for list_elem in stree.findall("L"):
-            items = list(list_elem.findall("LI"))
+        for list_elem in stree.find_all("L"):
+            items = list(list_elem.find_all("LI"))
             assert items
             for item in items:
-                body = list(item.findall("LBody"))
+                body = list(item.find_all("LBody"))
                 assert body
 
     def test_all_mcids(self):
@@ -906,7 +906,7 @@ class TestClass(unittest.TestCase):
         pdf = pdfplumber.open(path)
         # Make sure we can get them with page numbers
         stree = PDFStructTree(pdf)
-        sect = next(stree.findall("Sect"))
+        sect = next(stree.find_all("Sect"))
         mcids = list(sect.all_mcids())
         pages = set(page for page, mcid in mcids)
         assert 1 in pages
@@ -915,15 +915,35 @@ class TestClass(unittest.TestCase):
         # (FIXME: may wish to reconsider this API decision...)
         page = pdf.pages[1]
         stree = PDFStructTree(pdf, page)
-        sect = next(stree.findall("Sect"))
+        sect = next(stree.find_all("Sect"))
         mcids = list(sect.all_mcids())
         pages = set(page for page, mcid in mcids)
         assert None in pages
         assert 1 not in pages
         assert 2 not in pages
         # Assure that we get the MCIDs for a content element
-        for p in sect.findall("P"):
+        for p in sect.find_all("P"):
             assert set(mcid for page, mcid in p.all_mcids()) == set(p.mcids)
+
+    def test_element_bbox(self):
+        """
+        Test various ways of getting element bboxes
+        """
+        path = os.path.join(HERE, "pdfs/pdf_structure.pdf")
+        pdf = pdfplumber.open(path)
+        stree = PDFStructTree(pdf)
+        # As BBox attribute
+        table = next(stree.find_all("Table"))
+        assert tuple(stree.element_bbox(table)) == (56.7, 489.9, 555.3, 542.25)
+        # With child elements
+        tr = next(table.find_all("TR"))
+        assert tuple(stree.element_bbox(tr)) == (56.8, 495.9, 328.312, 507.9)
+        # From a specific page it should also work
+        stree = PDFStructTree(pdf, pdf.pages[0])
+        table = next(stree.find_all("Table"))
+        assert tuple(stree.element_bbox(table)) == (56.7, 489.9, 555.3, 542.25)
+        tr = next(table.find_all("TR"))
+        assert tuple(stree.element_bbox(tr)) == (56.8, 495.9, 328.312, 507.9)
 
 
 class TestUnparsed(unittest.TestCase):

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -875,6 +875,7 @@ class TestClass(unittest.TestCase):
         assert len(figs) == 1
         fig = stree.find("Figure")
         assert fig == figs[0]
+        assert stree.find("Fogure") is None
         figs = list(stree.find_all(re.compile(r"Fig.*")))
         assert len(figs) == 1
         figs = list(stree.find_all(lambda x: x.type == "Figure"))
@@ -901,6 +902,7 @@ class TestClass(unittest.TestCase):
                 assert body
                 body1 = item.find("LBody")
                 assert body1 == body[0]
+                assert item.find("Loonie") is None
 
     def test_all_mcids(self):
         """

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -921,6 +921,9 @@ class TestClass(unittest.TestCase):
         assert None in pages
         assert 1 not in pages
         assert 2 not in pages
+        # Assure that we get the MCIDs for a content element
+        for p in sect.findall("P"):
+            assert set(mcid for page, mcid in p.all_mcids()) == set(p.mcids)
 
 
 class TestUnparsed(unittest.TestCase):

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -944,6 +944,18 @@ class TestClass(unittest.TestCase):
         assert tuple(stree.element_bbox(table)) == (56.7, 489.9, 555.3, 542.25)
         tr = next(table.find_all("TR"))
         assert tuple(stree.element_bbox(tr)) == (56.8, 495.9, 328.312, 507.9)
+        # Yeah but what happens if you crop the page?
+        page = pdf.pages[0].crop((10, 400, 500, 500))
+        stree = PDFStructTree(pdf, page)
+        table = next(stree.find_all("Table"))
+        # The element gets cropped too
+        assert tuple(stree.element_bbox(table)) == (56.7, 489.9, 500, 500)
+        # And if you crop it out of the page?
+        page = pdf.pages[0].crop((0, 0, 560, 400))
+        stree = PDFStructTree(pdf, page)
+        table = next(stree.find_all("Table"))
+        with self.assertRaises(IndexError):
+            _ = stree.element_bbox(table)
 
 
 class TestUnparsed(unittest.TestCase):

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -866,13 +866,15 @@ class TestClass(unittest.TestCase):
 
     def test_find_all_tree(self):
         """
-        Test find_all() on trees
+        Test find_all() and find() on trees
         """
         path = os.path.join(HERE, "pdfs/image_structure.pdf")
         pdf = pdfplumber.open(path)
         stree = PDFStructTree(pdf, pdf.pages[0])
         figs = list(stree.find_all("Figure"))
         assert len(figs) == 1
+        fig = stree.find("Figure")
+        assert fig == figs[0]
         figs = list(stree.find_all(re.compile(r"Fig.*")))
         assert len(figs) == 1
         figs = list(stree.find_all(lambda x: x.type == "Figure"))
@@ -886,7 +888,7 @@ class TestClass(unittest.TestCase):
 
     def test_find_all_element(self):
         """
-        Test find_all() on elements
+        Test find_all() and find() on elements
         """
         path = os.path.join(HERE, "pdfs/pdf_structure.pdf")
         pdf = pdfplumber.open(path)
@@ -897,6 +899,8 @@ class TestClass(unittest.TestCase):
             for item in items:
                 body = list(item.find_all("LBody"))
                 assert body
+                body1 = item.find("LBody")
+                assert body1 == body[0]
 
     def test_all_mcids(self):
         """


### PR DESCRIPTION
It's useful to be able to search in the structure tree - this has to be done from the `PDFStructTree` object itself since we return a dictionary from `structure_tree` in keeping with the general way of `pdfplumber`.

Also to get a BBox from an element for  visual debugging - note the FIXME, if you play games with cropped pages, this will fail, but in general that's unlikely, you would have to do something like:

```python
pdf = pdfplumber.open(pdffile)
page = pdf.pages[0].crop(some_bbox)
stree = PDFStructTree(pdf, page)  # NO! Don't do this! Why would you do this?
```
and then try to get the BBox of an element where it is explicitly specified in the attributes of that element (usually this is only the case for `Figure` and `Table`).

Is there a general method to properly transform PDF BBoxes into `pdfplumber` ones for a page?