### PR TITLE
Feature: Warn on unicode decoding errors in PDF annotations

### DIFF
--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -312,7 +312,10 @@ class Page(Container):
                         except UnicodeDecodeError:
                             if self.pdf.raise_unicode_errors:
                                 raise
-                            warn(f"Could not decode {k} for annotation. {k} will be missing.")
+                            warn(
+                                f"Could not decode {k} for annotation."
+                                " {k} will be missing."
+                            )
 
             parsed = {
                 "page_number": self.page_number,

--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -313,8 +313,8 @@ class Page(Container):
                             if self.pdf.raise_unicode_errors:
                                 raise
                             warn(
-                                f"Could not decode {k} for annotation."
-                                " {k} will be missing."
+                                f"Could not decode {k} of annotation."
+                                f" {k} will be missing."
                             )
 
             parsed = {

--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -13,6 +13,7 @@ from typing import (
     Union,
 )
 from unicodedata import normalize as normalize_unicode
+from warnings import warn
 
 from pdfminer.converter import PDFPageAggregator
 from pdfminer.layout import (
@@ -306,7 +307,12 @@ class Page(Container):
                     try:
                         extras[k] = v.decode("utf-8")
                     except UnicodeDecodeError:
-                        extras[k] = v.decode("utf-16")
+                        try:
+                            extras[k] = v.decode("utf-16")
+                        except UnicodeDecodeError:
+                            if not self.pdf.warn_unicode_error:
+                                raise
+                            warn(f"Could not decode {k} for annotation. {k} will be missing.")
 
             parsed = {
                 "page_number": self.page_number,

--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -310,7 +310,7 @@ class Page(Container):
                         try:
                             extras[k] = v.decode("utf-16")
                         except UnicodeDecodeError:
-                            if not self.pdf.warn_unicode_error:
+                            if self.pdf.raise_unicode_errors:
                                 raise
                             warn(f"Could not decode {k} for annotation. {k} will be missing.")
 

--- a/pdfplumber/pdf.py
+++ b/pdfplumber/pdf.py
@@ -35,7 +35,7 @@ class PDF(Container):
         password: Optional[str] = None,
         strict_metadata: bool = False,
         unicode_norm: Optional[Literal["NFC", "NFKC", "NFD", "NFKD"]] = None,
-        warn_unicode_error: bool = False,
+        raise_unicode_errors: bool = True,
     ):
         self.stream = stream
         self.stream_is_external = stream_is_external
@@ -44,7 +44,7 @@ class PDF(Container):
         self.laparams = None if laparams is None else LAParams(**laparams)
         self.password = password
         self.unicode_norm = unicode_norm
-        self.warn_unicode_error = warn_unicode_error
+        self.raise_unicode_errors = raise_unicode_errors
 
         self.doc = PDFDocument(PDFParser(stream), password=password or "")
         self.rsrcmgr = PDFResourceManager()
@@ -78,7 +78,7 @@ class PDF(Container):
         repair: bool = False,
         gs_path: Optional[Union[str, pathlib.Path]] = None,
         repair_setting: T_repair_setting = "default",
-        warn_unicode_error: bool = False,
+        raise_unicode_errors: bool = True,
     ) -> "PDF":
 
         stream: Union[BufferedReader, BytesIO]
@@ -110,7 +110,7 @@ class PDF(Container):
                 strict_metadata=strict_metadata,
                 unicode_norm=unicode_norm,
                 stream_is_external=stream_is_external,
-                warn_unicode_error=warn_unicode_error,
+                raise_unicode_errors=raise_unicode_errors,
             )
 
         except PSException:

--- a/pdfplumber/pdf.py
+++ b/pdfplumber/pdf.py
@@ -35,6 +35,7 @@ class PDF(Container):
         password: Optional[str] = None,
         strict_metadata: bool = False,
         unicode_norm: Optional[Literal["NFC", "NFKC", "NFD", "NFKD"]] = None,
+        warn_unicode_error: bool = False,
     ):
         self.stream = stream
         self.stream_is_external = stream_is_external
@@ -43,6 +44,7 @@ class PDF(Container):
         self.laparams = None if laparams is None else LAParams(**laparams)
         self.password = password
         self.unicode_norm = unicode_norm
+        self.warn_unicode_error = warn_unicode_error
 
         self.doc = PDFDocument(PDFParser(stream), password=password or "")
         self.rsrcmgr = PDFResourceManager()
@@ -76,6 +78,7 @@ class PDF(Container):
         repair: bool = False,
         gs_path: Optional[Union[str, pathlib.Path]] = None,
         repair_setting: T_repair_setting = "default",
+        warn_unicode_error: bool = False,
     ) -> "PDF":
 
         stream: Union[BufferedReader, BytesIO]
@@ -107,6 +110,7 @@ class PDF(Container):
                 strict_metadata=strict_metadata,
                 unicode_norm=unicode_norm,
                 stream_is_external=stream_is_external,
+                warn_unicode_error=warn_unicode_error,
             )
 
         except PSException:

--- a/tests/pdfs/annotations-unicode-issues.pdf
+++ b/tests/pdfs/annotations-unicode-issues.pdf
@@ -1,0 +1,587 @@
+%PDF-1.3
+%âãÏÓ
+1 0 obj
+<<
+/Type /Pages
+/Count 1
+/Kids [ 4 0 R ]
+>>
+endobj
+2 0 obj
+<<
+/Producer (PyPDF2)
+>>
+endobj
+3 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+>>
+endobj
+4 0 obj
+<<
+/Annots 5 0 R
+/Type /Page
+/MediaBox [ 0 0 595.28 841.89 ]
+/Resources 29 0 R
+/Rotate 0
+/Contents 35 0 R
+/Parent 1 0 R
+>>
+endobj
+5 0 obj
+[ 6 0 R ]
+endobj
+6 0 obj
+<<
+/AAPL:AKExtras <<
+/AAPL:AKPDFAnnotationDictionary <<
+/AAPL:AKExtras <<
+/AAPL:AKAnnotationObject (YnBsaXN0MDDUAQIDBAUGBwpYJHZlcnNpb25ZJGFyY2hpdmVyVCR0b3BYJG9iamVjdHMSAAGGoF8QD05TS2V5ZWRBcmNoaXZlctEICVRyb290gAGvECoLDEJDREhOT11eX2BhYmNkZWltcXd4goOEhY6UlZmcpKeqrra3urzAw81VJG51bGzfEBwNDg8QERITFBUWFxgZGhscHR4fICEiIyQlJicoKSorKi0uLzAxKjAqNC01Njc0OCopKjc9Pj9AQV8QGHNob3VsZFVzZVBsYWNlaG9sZGVyVGV4dF8QEXRleHRJc0ZpeGVkSGVpZ2h0XxATdHlwaW5nQXR0cmlidXRlc1JURl8QEHRleHRJc0ZpeGVkV2lkdGhfEBdvcmlnaW5hbEV4aWZPcmllbnRhdGlvbl8QHG9yaWdpbmFsTW9kZWxCYXNlU2NhbGVGYWN0b3JWJGNsYXNzXXJvdGF0aW9uQW5nbGVWYWtWZXJzXxAQQUtJc0Zvcm1GaWVsZEtleVtzdHJva2VXaWR0aF10ZXh0SXNDbGlwcGVkWmJydXNoU3R5bGVWYWtQbGF0XxAPZmlsbENvbG9yU3RyaW5nXxAQbW9kaWZpY2F0aW9uRGF0ZV8QEXN0cm9rZUNvbG9yU3RyaW5nXxAPZm9ybUNvbnRlbnRUeXBlVFVVSURZaGFzU2hhZG93XxAeZWRpdHNEaXNhYmxlQXBwZWFyYW5jZU92ZXJyaWRlVmRhc2hlZF8QFWN1c3RvbVBsYWNlaG9sZGVyVGV4dFlyZWN0YW5nbGVfEBBhdHRyaWJ1dGVkU3RyaW5nXxAQdHlwaW5nQXR0cmlidXRlc1ZhdXRob3JfEBFhbm5vdGF0aW9uVGV4dFJURgkIgCcIEAEjP\053IRAPHUi8\053AKSMAAAAAAAAAABACCAgQAIAGgASAAIACCAkIgACAB4ATgCiAA4ARXxAkNEYxQkJBMzktMTg0MC00QzE3LTg4OEMtRUFEMjA2M0FGODk5XxARTWljaGFsIFN0b2xhcmN6eWvSRRNGR1dOUy50aW1lI0HGeGtRV\053GxgAXSSUpLTFokY2xhc3NuYW1lWCRjbGFzc2VzVk5TRGF0ZaJLTVhOU09iamVjdF4xIDAuMTQ5MTMxIDAgMdNQURNSV1xXTlMua2V5c1pOUy5vYmplY3RzpFNUVVaACIAJgAqAC6RYWVpbgAyADYAOgA\053AEFVXaWR0aFZIZWlnaHRRWVFYI0BJHfzAtV9tI0AghEA8dSL0I0CBgbRuJmpKI0Bw\057A8yrqNp0klKZmdfEBNOU011dGFibGVEaWN0aW9uYXJ5o2ZoTVxOU0RpY3Rpb25hcnnSahNrbFdOUy5kYXRhTxEBHntccnRmMVxhbnNpXGFuc2ljcGcxMjUyXGNvY29hcnRmMjc2MQpcY29jb2F0ZXh0c2NhbGluZzBcY29jb2FwbGF0Zm9ybTB7XGZvbnR0YmxcZjBcZm5pbFxmY2hhcnNldDAgVGFob21hO30Ke1xjb2xvcnRibDtccmVkMjU1XGdyZWVuMjU1XGJsdWUyNTU7XHJlZDBcZ3JlZW4wXGJsdWUwO30Ke1wqXGV4cGFuZGVkY29sb3J0Ymw7O1xjc3NyZ2JcYzBcYzBcYzA7fQpccGFyZFxwYXJkaXJuYXR1cmFsXHFjXHBhcnRpZ2h0ZW5mYWN0b3IwCgpcZjBcZnMxOCBcY2YyIGludmFsaWQgdXRmLTggXFx4ODBcXHg4MH2AEtJJSm5vXU5TTXV0YWJsZURhdGGjbnBNVk5TRGF0YdNyE3N0dXZYTlNTdHJpbmdcTlNBdHRyaWJ1dGVzgBSAJoAVXxAWaW52YWxpZCB1dGYtOCBceDgwXHg4MNNQURN5fYGjent8gBaAF4AYo35\057gIAZgB6AIoAlV05TQ29sb3JfEBBOU1BhcmFncmFwaFN0eWxlVk5TRm9udNWGh4iJE4qLLYyNXE5TQ29tcG9uZW50c1VOU1JHQlxOU0NvbG9yU3BhY2VfEBJOU0N1c3RvbUNvbG9yU3BhY2VHMCAwIDAgMUYwIDAgMACAGoAd04\053QE5GSk1ROU0lEVU5TSUNDEAeAG4AcTxEMSAAADEhMaW5vAhAAAG1udHJSR0IgWFlaIAfOAAIACQAGADEAAGFjc3BNU0ZUAAAAAElFQyBzUkdCAAAAAAAAAAAAAAAAAAD21gABAAAAANMtSFAgIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEWNwcnQAAAFQAAAAM2Rlc2MAAAGEAAAAbHd0cHQAAAHwAAAAFGJrcHQAAAIEAAAAFHJYWVoAAAIYAAAAFGdYWVoAAAIsAAAAFGJYWVoAAAJAAAAAFGRtbmQAAAJUAAAAcGRtZGQAAALEAAAAiHZ1ZWQAAANMAAAAhnZpZXcAAAPUAAAAJGx1bWkAAAP4AAAAFG1lYXMAAAQMAAAAJHRlY2gAAAQwAAAADHJUUkMAAAQ8AAAIDGdUUkMAAAQ8AAAIDGJUUkMAAAQ8AAAIDHRleHQAAAAAQ29weXJpZ2h0IChjKSAxOTk4IEhld2xldHQtUGFja2FyZCBDb21wYW55AABkZXNjAAAAAAAAABJzUkdCIElFQzYxOTY2LTIuMQAAAAAAAAAAAAAAEnNSR0IgSUVDNjE5NjYtMi4xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABYWVogAAAAAAAA81EAAQAAAAEWzFhZWiAAAAAAAAAAAAAAAAAAAAAAWFlaIAAAAAAAAG\053iAAA49QAAA5BYWVogAAAAAAAAYpkAALeFAAAY2lhZWiAAAAAAAAAkoAAAD4QAALbPZGVzYwAAAAAAAAAWSUVDIGh0dHA6Ly93d3cuaWVjLmNoAAAAAAAAAAAAAAAWSUVDIGh0dHA6Ly93d3cuaWVjLmNoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGRlc2MAAAAAAAAALklFQyA2MTk2Ni0yLjEgRGVmYXVsdCBSR0IgY29sb3VyIHNwYWNlIC0gc1JHQgAAAAAAAAAAAAAALklFQyA2MTk2Ni0yLjEgRGVmYXVsdCBSR0IgY29sb3VyIHNwYWNlIC0gc1JHQgAAAAAAAAAAAAAAAAAAAAAAAAAAAABkZXNjAAAAAAAAACxSZWZlcmVuY2UgVmlld2luZyBDb25kaXRpb24gaW4gSUVDNjE5NjYtMi4xAAAAAAAAAAAAAAAsUmVmZXJlbmNlIFZpZXdpbmcgQ29uZGl0aW9uIGluIElFQzYxOTY2LTIuMQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAdmlldwAAAAAAE6T\053ABRfLgAQzxQAA\0533MAAQTCwADXJ4AAAABWFlaIAAAAAAATAlWAFAAAABXH\053dtZWFzAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAACjwAAAAJzaWcgAAAAAENSVCBjdXJ2AAAAAAAABAAAAAAFAAoADwAUABkAHgAjACgALQAyADcAOwBAAEUASgBPAFQAWQBeAGMAaABtAHIAdwB8AIEAhgCLAJAAlQCaAJ8ApACpAK4AsgC3ALwAwQDGAMsA0ADVANsA4ADlAOsA8AD2APsBAQEHAQ0BEwEZAR8BJQErATIBOAE\053AUUBTAFSAVkBYAFnAW4BdQF8AYMBiwGSAZoBoQGpAbEBuQHBAckB0QHZAeEB6QHyAfoCAwIMAhQCHQImAi8COAJBAksCVAJdAmcCcQJ6AoQCjgKYAqICrAK2AsECywLVAuAC6wL1AwADCwMWAyEDLQM4A0MDTwNaA2YDcgN\053A4oDlgOiA64DugPHA9MD4APsA\057kEBgQTBCAELQQ7BEgEVQRjBHEEfgSMBJoEqAS2BMQE0wThBPAE\057gUNBRwFKwU6BUkFWAVnBXcFhgWWBaYFtQXFBdUF5QX2BgYGFgYnBjcGSAZZBmoGewaMBp0GrwbABtEG4wb1BwcHGQcrBz0HTwdhB3QHhgeZB6wHvwfSB\053UH\053AgLCB8IMghGCFoIbgiCCJYIqgi\053CNII5wj7CRAJJQk6CU8JZAl5CY8JpAm6Cc8J5Qn7ChEKJwo9ClQKagqBCpgKrgrFCtwK8wsLCyILOQtRC2kLgAuYC7ALyAvhC\057kMEgwqDEMMXAx1DI4MpwzADNkM8w0NDSYNQA1aDXQNjg2pDcMN3g34DhMOLg5JDmQOfw6bDrYO0g7uDwkPJQ9BD14Peg\053WD7MPzw\057sEAkQJhBDEGEQfhCbELkQ1xD1ERMRMRFPEW0RjBGqEckR6BIHEiYSRRJkEoQSoxLDEuMTAxMjE0MTYxODE6QTxRPlFAYUJxRJFGoUixStFM4U8BUSFTQVVhV4FZsVvRXgFgMWJhZJFmwWjxayFtYW\053hcdF0EXZReJF64X0hf3GBsYQBhlGIoYrxjVGPoZIBlFGWsZkRm3Gd0aBBoqGlEadxqeGsUa7BsUGzsbYxuKG7Ib2hwCHCocUhx7HKMczBz1HR4dRx1wHZkdwx3sHhYeQB5qHpQevh7pHxMfPh9pH5Qfvx\057qIBUgQSBsIJggxCDwIRwhSCF1IaEhziH7IiciVSKCIq8i3SMKIzgjZiOUI8Ij8CQfJE0kfCSrJNolCSU4JWgllyXHJfcmJyZXJocmtyboJxgnSSd6J6sn3CgNKD8ocSiiKNQpBik4KWspnSnQKgIqNSpoKpsqzysCKzYraSudK9EsBSw5LG4soizXLQwtQS12Last4S4WLkwugi63Lu4vJC9aL5Evxy\057\053MDUwbDCkMNsxEjFKMYIxujHyMioyYzKbMtQzDTNGM38zuDPxNCs0ZTSeNNg1EzVNNYc1wjX9Njc2cjauNuk3JDdgN5w31zgUOFA4jDjIOQU5Qjl\057Obw5\053To2OnQ6sjrvOy07azuqO\053g8JzxlPKQ84z0iPWE9oT3gPiA\053YD6gPuA\057IT9hP6I\0574kAjQGRApkDnQSlBakGsQe5CMEJyQrVC90M6Q31DwEQDREdEikTORRJFVUWaRd5GIkZnRqtG8Ec1R3tHwEgFSEtIkUjXSR1JY0mpSfBKN0p9SsRLDEtTS5pL4kwqTHJMuk0CTUpNk03cTiVObk63TwBPSU\053TT91QJ1BxULtRBlFQUZtR5lIxUnxSx1MTU19TqlP2VEJUj1TbVShVdVXCVg9WXFapVvdXRFeSV\053BYL1h9WMtZGllpWbhaB1pWWqZa9VtFW5Vb5Vw1XIZc1l0nXXhdyV4aXmxevV8PX2Ffs2AFYFdgqmD8YU9homH1YklinGLwY0Njl2PrZEBklGTpZT1lkmXnZj1mkmboZz1nk2fpaD9olmjsaUNpmmnxakhqn2r3a09rp2v\057bFdsr20IbWBtuW4SbmtuxG8eb3hv0XArcIZw4HE6cZVx8HJLcqZzAXNdc7h0FHRwdMx1KHWFdeF2Pnabdvh3VnezeBF4bnjMeSp5iXnnekZ6pXsEe2N7wnwhfIF84X1BfaF\053AX5ifsJ\057I3\053Ef\053WAR4CogQqBa4HNgjCCkoL0g1eDuoQdhICE44VHhauGDoZyhteHO4efiASIaYjOiTOJmYn\053imSKyoswi5aL\057IxjjMqNMY2Yjf\053OZo7OjzaPnpAGkG6Q1pE\057kaiSEZJ6kuOTTZO2lCCUipT0lV\053VyZY0lp\053XCpd1l\053CYTJi4mSSZkJn8mmia1ZtCm6\053cHJyJnPedZJ3SnkCerp8dn4uf\053qBpoNihR6G2oiailqMGo3aj5qRWpMelOKWpphqmi6b9p26n4KhSqMSpN6mpqhyqj6sCq3Wr6axcrNCtRK24ri2uoa8Wr4uwALB1sOqxYLHWskuywrM4s660JbSctRO1irYBtnm28Ldot\053C4WbjRuUq5wro7urW7LrunvCG8m70VvY\053\053Cr6Evv\053\057er\0571wHDA7MFnwePCX8Lbw1jD1MRRxM7FS8XIxkbGw8dBx7\057IPci8yTrJuco4yrfLNsu2zDXMtc01zbXONs62zzfPuNA50LrRPNG\0530j\057SwdNE08bUSdTL1U7V0dZV1tjXXNfg2GTY6Nls2fHadtr724DcBdyK3RDdlt4c3qLfKd\053v4DbgveFE4cziU\053Lb42Pj6\053Rz5PzlhOYN5pbnH\053ep6DLovOlG6dDqW\053rl63Dr\053\053yG7RHtnO4o7rTvQO\057M8Fjw5fFy8f\057yjPMZ86f0NPTC9VD13vZt9vv3ivgZ\053Kj5OPnH\053lf65\057t3\057Af8mP0p\057br\053S\0577c\05723\057\0579JJSpaXXE5TQ29sb3JTcGFjZaKYTVxOU0NvbG9yU3BhY2XSSUqam1dOU0NvbG9yoppN1Z2eE5\053goTGiLaFaTlNUYWJTdG9wc1tOU0FsaWdubWVudF8QH05TQWxsb3dzVGlnaHRlbmluZ0ZvclRydW5jYXRpb25bTlNUZXh0TGlzdHOAH4AhgB\057SUROlpqCAINJJSqipV05TQXJyYXmiqE3SSUqrrF8QF05TTXV0YWJsZVBhcmFncmFwaFN0eWxlo6utTV8QEE5TUGFyYWdyYXBoU3R5bGXUr7CxE7KztLVWTlNTaXplWE5TZkZsYWdzVk5TTmFtZSNAIgAAAAAAABAQgCOAJFZUYWhvbWHSSUq4uVZOU0ZvbnSiuE3SSUpou6JoTdJJSr2\053XxASTlNBdHRyaWJ1dGVkU3RyaW5nor9NXxASTlNBdHRyaWJ1dGVkU3RyaW5n0moTwWxPEQEHe1xydGYxXGFuc2lcYW5zaWNwZzEyNTJcY29jb2FydGYyNzYxClxjb2NvYXRleHRzY2FsaW5nMFxjb2NvYXBsYXRmb3JtMHtcZm9udHRibFxmMFxmbmlsXGZjaGFyc2V0MCBUYWhvbWE7fQp7XGNvbG9ydGJsO1xyZWQyNTVcZ3JlZW4yNTVcYmx1ZTI1NTtccmVkMFxncmVlbjBcYmx1ZTA7fQp7XCpcZXhwYW5kZWRjb2xvcnRibDs7XGNzc3JnYlxjMFxjMFxjMDt9ClxwYXJkXHBhcmRpcm5hdHVyYWxccWNccGFydGlnaHRlbmZhY3RvcjAKClxmMFxmczE4IFxjZjIgYX2AEtNQURPEyIGjent8gBaAF4AYo35\057gIAZgB6AIoAl0klKzs9fEBNBS1RleHRCb3hBbm5vdGF0aW9uptDR0tPUTV8QE0FLVGV4dEJveEFubm90YXRpb25fEBxBS1JlY3Rhbmd1bGFyU2hhcGVBbm5vdGF0aW9uXxARQUtTaGFwZUFubm90YXRpb25fEBNBS1N0cm9rZWRBbm5vdGF0aW9uXEFLQW5ub3RhdGlvbgAIABEAGgAkACkAMgA3AEkATABRAFMAgACGAMEA3ADwAQYBGQEzAVIBWQFnAW4BgQGNAZsBpgGtAb8B0gHmAfgB\057QIHAigCLwJHAlECZAJ3An4CkgKTApQClgKXApkCogKkAq0CrwKwArECswK1ArcCuQK7ArwCvQK\053AsACwgLEAsYCyALKAvEDBQMKAxIDGwMdAyIDLQM2Az0DQANJA1gDXwNnA3IDdwN5A3sDfQN\057A4QDhgOIA4oDjAOOA5QDmwOdA58DqAOxA7oDwwPIA94D4gPvA\057QD\057AUeBSAFJQUzBTcFPgVFBU4FWwVdBV8FYQV6BYEFhQWHBYkFiwWPBZEFkwWVBZcFnwWyBbkFxAXRBdcF5AX5BgEGCAYKBgwGEwYYBh4GIAYiBiQScBJ1EoIShRKSEpcSnxKiEq0SuBLEEuYS8hL0EvYS\053BL9Ev4TABMFEw0TEBMVEy8TMxNGE08TVhNfE2YTbxNxE3MTdRN8E4ETiBOLE5ATkxOYE60TsBPFE8oU1RTXFN4U4hTkFOYU6BTsFO4U8BTyFPQU\053RUPFRYVLBVLFV8VdQAAAAAAAAIBAAAAAAAAANUAAAAAAAAAAAAAAAAAABWC)
+>>
+/F 4
+/BS <<
+/W 0
+>>
+/Subtype /FreeText
+/DA (\057\057Helvetica\04012\040Tf\0400\040g)
+/Border [ 0 0 0 ]
+/Type /Annot
+/Rect [ 267.5255 559.2131 325.6696 569.4714 ]
+/M (D\07220241122152819Z00\04700\047)
+/IC [ 1 0.149131 0 ]
+/AP <<
+/N 7 0 R
+>>
+/Contents (þÿ\000i\000n\000v\000a\000l\000i\000d\000\040\000u\000t\000f\000\055\0008\000\040ÿý\000E\000D\000\040\000A\0000\000\040\0008\0000)
+/T (Michal\040Stolarczyk)
+>>
+/AAPL:AKAnnotationObject (YnBsaXN0MDDUAAEAAgADAAQABQAGAAcAClgkdmVyc2lvblkkYXJjaGl2ZXJUJHRvcFgkb2JqZWN0cxIAAYagXxAPTlNLZXllZEFyY2hpdmVy0QAIAAlUcm9vdIABrxA4AAsADABCAEMARABIAE4ATwBdAF4AXwBgAGEAYgBjAGQAZQBpAG0AcQB5AHoAfwCJAIoAiwCMAJUAmwCcAKAAowCrAK4AsQC1AL0AvgDBAMMAzwDQANcA2ADeAOYA5wC5AOgA6QDtAPAA8wD3APoBBFUkbnVsbN8QHAANAA4ADwAQABEAEgATABQAFQAWABcAGAAZABoAGwAcAB0AHgAfACAAIQAiACMAJAAlACYAJwAoACkAKgArACoALQAuAC8AMAAxACoAMAAqADQALQA1ADYANwA0ADgAKgApACoANwA9AD4APwBAAEFfEBhzaG91bGRVc2VQbGFjZWhvbGRlclRleHRfEBF0ZXh0SXNGaXhlZEhlaWdodF8QE3R5cGluZ0F0dHJpYnV0ZXNSVEZfEBB0ZXh0SXNGaXhlZFdpZHRoXxAXb3JpZ2luYWxFeGlmT3JpZW50YXRpb25fEBxvcmlnaW5hbE1vZGVsQmFzZVNjYWxlRmFjdG9yViRjbGFzc11yb3RhdGlvbkFuZ2xlVmFrVmVyc18QEEFLSXNGb3JtRmllbGRLZXlbc3Ryb2tlV2lkdGhddGV4dElzQ2xpcHBlZFpicnVzaFN0eWxlVmFrUGxhdF8QD2ZpbGxDb2xvclN0cmluZ18QEG1vZGlmaWNhdGlvbkRhdGVfEBFzdHJva2VDb2xvclN0cmluZ18QD2Zvcm1Db250ZW50VHlwZVRVVUlEWWhhc1NoYWRvd18QHmVkaXRzRGlzYWJsZUFwcGVhcmFuY2VPdmVycmlkZVZkYXNoZWRfEBVjdXN0b21QbGFjZWhvbGRlclRleHRZcmVjdGFuZ2xlXxAQYXR0cmlidXRlZFN0cmluZ18QEHR5cGluZ0F0dHJpYnV0ZXNWYXV0aG9yXxARYW5ub3RhdGlvblRleHRSVEYJCIA1CBABIz\057iEQDx1IvPgDcjAAAAAAAAAAAQAggIEACABoAEgACAAggJCIAAgAeAE4A2gAOAEV8QJDRGMUJCQTM5LTE4NDAtNEMxNy04ODhDLUVBRDIwNjNBRjg5OV8QEU1pY2hhbCBTdG9sYXJjenlr0gBFABMARgBHV05TLnRpbWUjQcZ4bUmsDaKABdIASQBKAEsATFokY2xhc3NuYW1lWCRjbGFzc2VzVk5TRGF0ZaIASwBNWE5TT2JqZWN0XjEgMC4xNDkxMzEgMCAx0wBQAFEAEwBSAFcAXFdOUy5rZXlzWk5TLm9iamVjdHOkAFMAVABVAFaACIAJgAqAC6QAWABZAFoAW4AMgA2ADoAPgBBVV2lkdGhWSGVpZ2h0UVlRWCNATBJyt0MR9SNAIIRAPHUi9CNAgYG0biZqSiNAcMhofN09AtIASQBKAGYAZ18QE05TTXV0YWJsZURpY3Rpb25hcnmjAGYAaABNXE5TRGljdGlvbmFyedIAagATAGsAbFdOUy5kYXRhTxEBKHtccnRmMVxhbnNpXGFuc2ljcGcxMjUyXGNvY29hcnRmMjc2MQpcY29jb2F0ZXh0c2NhbGluZzBcY29jb2FwbGF0Zm9ybTB7XGZvbnR0YmxcZjBcZm5pbFxmY2hhcnNldDAgVGFob21hO30Ke1xjb2xvcnRibDtccmVkMjU1XGdyZWVuMjU1XGJsdWUyNTU7XHJlZDBcZ3JlZW4wXGJsdWUwO30Ke1wqXGV4cGFuZGVkY29sb3J0Ymw7O1xjc3NyZ2JcYzBcYzBcYzA7fQpccGFyZFxwYXJkaXJuYXR1cmFsXHFjXHBhcnRpZ2h0ZW5mYWN0b3IwCgpcZjBcZnMxOCBcY2YyIGludmFsaWQgdXRmLTggXHVjMFx1NjU1MzMgRUQgQTAgODB9gBLSAEkASgBuAG9dTlNNdXRhYmxlRGF0YaMAbgBwAE1WTlNEYXRh1AByAHMAdAATAHUAdgB3AHhYTlNTdHJpbmdfEA9OU0F0dHJpYnV0ZUluZm9cTlNBdHRyaWJ1dGVzgBSAM4AVgDRvEBcAaQBuAHYAYQBsAGkAZAAgAHUAdABmAC0AOAAg\057\0570ARQBEACAAQQAwACAAOAAw0gBRABMAewB\053ogB8AH2AFoAngDLTAFAAUQATAIAAhACIowCBAIIAg4AXgBiAGaMAhQCGAIeAGoAfgCOAJldOU0NvbG9yXxAQTlNQYXJhZ3JhcGhTdHlsZVZOU0ZvbnTVAI0AjgCPAJAAEwCRAJIALQCTAJRcTlNDb21wb25lbnRzVU5TUkdCXE5TQ29sb3JTcGFjZV8QEk5TQ3VzdG9tQ29sb3JTcGFjZUcwIDAgMCAxRjAgMCAwAIAbgB7TAJYAlwATAJgAmQCaVE5TSURVTlNJQ0MQB4AcgB1PEQxIAAAMSExpbm8CEAAAbW50clJHQiBYWVogB84AAgAJAAYAMQAAYWNzcE1TRlQAAAAASUVDIHNSR0IAAAAAAAAAAAAAAAAAAPbWAAEAAAAA0y1IUCAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARY3BydAAAAVAAAAAzZGVzYwAAAYQAAABsd3RwdAAAAfAAAAAUYmtwdAAAAgQAAAAUclhZWgAAAhgAAAAUZ1hZWgAAAiwAAAAUYlhZWgAAAkAAAAAUZG1uZAAAAlQAAABwZG1kZAAAAsQAAACIdnVlZAAAA0wAAACGdmlldwAAA9QAAAAkbHVtaQAAA\057gAAAAUbWVhcwAABAwAAAAkdGVjaAAABDAAAAAMclRSQwAABDwAAAgMZ1RSQwAABDwAAAgMYlRSQwAABDwAAAgMdGV4dAAAAABDb3B5cmlnaHQgKGMpIDE5OTggSGV3bGV0dC1QYWNrYXJkIENvbXBhbnkAAGRlc2MAAAAAAAAAEnNSR0IgSUVDNjE5NjYtMi4xAAAAAAAAAAAAAAASc1JHQiBJRUM2MTk2Ni0yLjEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFhZWiAAAAAAAADzUQABAAAAARbMWFlaIAAAAAAAAAAAAAAAAAAAAABYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9kZXNjAAAAAAAAABZJRUMgaHR0cDovL3d3dy5pZWMuY2gAAAAAAAAAAAAAABZJRUMgaHR0cDovL3d3dy5pZWMuY2gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZGVzYwAAAAAAAAAuSUVDIDYxOTY2LTIuMSBEZWZhdWx0IFJHQiBjb2xvdXIgc3BhY2UgLSBzUkdCAAAAAAAAAAAAAAAuSUVDIDYxOTY2LTIuMSBEZWZhdWx0IFJHQiBjb2xvdXIgc3BhY2UgLSBzUkdCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGRlc2MAAAAAAAAALFJlZmVyZW5jZSBWaWV3aW5nIENvbmRpdGlvbiBpbiBJRUM2MTk2Ni0yLjEAAAAAAAAAAAAAACxSZWZlcmVuY2UgVmlld2luZyBDb25kaXRpb24gaW4gSUVDNjE5NjYtMi4xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB2aWV3AAAAAAATpP4AFF8uABDPFAAD7cwABBMLAANcngAAAAFYWVogAAAAAABMCVYAUAAAAFcf521lYXMAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAKPAAAAAnNpZyAAAAAAQ1JUIGN1cnYAAAAAAAAEAAAAAAUACgAPABQAGQAeACMAKAAtADIANwA7AEAARQBKAE8AVABZAF4AYwBoAG0AcgB3AHwAgQCGAIsAkACVAJoAnwCkAKkArgCyALcAvADBAMYAywDQANUA2wDgAOUA6wDwAPYA\053wEBAQcBDQETARkBHwElASsBMgE4AT4BRQFMAVIBWQFgAWcBbgF1AXwBgwGLAZIBmgGhAakBsQG5AcEByQHRAdkB4QHpAfIB\053gIDAgwCFAIdAiYCLwI4AkECSwJUAl0CZwJxAnoChAKOApgCogKsArYCwQLLAtUC4ALrAvUDAAMLAxYDIQMtAzgDQwNPA1oDZgNyA34DigOWA6IDrgO6A8cD0wPgA\053wD\053QQGBBMEIAQtBDsESARVBGMEcQR\053BIwEmgSoBLYExATTBOEE8AT\053BQ0FHAUrBToFSQVYBWcFdwWGBZYFpgW1BcUF1QXlBfYGBgYWBicGNwZIBlkGagZ7BowGnQavBsAG0QbjBvUHBwcZBysHPQdPB2EHdAeGB5kHrAe\057B9IH5Qf4CAsIHwgyCEYIWghuCIIIlgiqCL4I0gjnCPsJEAklCToJTwlkCXkJjwmkCboJzwnlCfsKEQonCj0KVApqCoEKmAquCsUK3ArzCwsLIgs5C1ELaQuAC5gLsAvIC\053EL\053QwSDCoMQwxcDHUMjgynDMAM2QzzDQ0NJg1ADVoNdA2ODakNww3eDfgOEw4uDkkOZA5\057DpsOtg7SDu4PCQ8lD0EPXg96D5YPsw\057PD\053wQCRAmEEMQYRB\053EJsQuRDXEPURExExEU8RbRGMEaoRyRHoEgcSJhJFEmQShBKjEsMS4xMDEyMTQxNjE4MTpBPFE\053UUBhQnFEkUahSLFK0UzhTwFRIVNBVWFXgVmxW9FeAWAxYmFkkWbBaPFrIW1hb6Fx0XQRdlF4kXrhfSF\057cYGxhAGGUYihivGNUY\053hkgGUUZaxmRGbcZ3RoEGioaURp3Gp4axRrsGxQbOxtjG4obshvaHAIcKhxSHHscoxzMHPUdHh1HHXAdmR3DHeweFh5AHmoelB6\053HukfEx8\053H2kflB\053\057H\053ogFSBBIGwgmCDEIPAhHCFIIXUhoSHOIfsiJyJVIoIiryLdIwojOCNmI5QjwiPwJB8kTSR8JKsk2iUJJTglaCWXJccl9yYnJlcmhya3JugnGCdJJ3onqyfcKA0oPyhxKKIo1CkGKTgpaymdKdAqAio1KmgqmyrPKwIrNitpK50r0SwFLDksbiyiLNctDC1BLXYtqy3hLhYuTC6CLrcu7i8kL1ovkS\057HL\0574wNTBsMKQw2zESMUoxgjG6MfIyKjJjMpsy1DMNM0YzfzO4M\057E0KzRlNJ402DUTNU01hzXCNf02NzZyNq426TckN2A3nDfXOBQ4UDiMOMg5BTlCOX85vDn5OjY6dDqyOu87LTtrO6o76DwnPGU8pDzjPSI9YT2hPeA\053ID5gPqA\0534D8hP2E\057oj\057iQCNAZECmQOdBKUFqQaxB7kIwQnJCtUL3QzpDfUPARANER0SKRM5FEkVVRZpF3kYiRmdGq0bwRzVHe0fASAVIS0iRSNdJHUljSalJ8Eo3Sn1KxEsMS1NLmkviTCpMcky6TQJNSk2TTdxOJU5uTrdPAE9JT5NP3VAnUHFQu1EGUVBRm1HmUjFSfFLHUxNTX1OqU\057ZUQlSPVNtVKFV1VcJWD1ZcVqlW91dEV5JX4FgvWH1Yy1kaWWlZuFoHWlZaplr1W0VblVvlXDVchlzWXSddeF3JXhpebF69Xw9fYV\053zYAVgV2CqYPxhT2GiYfViSWKcYvBjQ2OXY\053tkQGSUZOllPWWSZedmPWaSZuhnPWeTZ\053loP2iWaOxpQ2maafFqSGqfavdrT2una\0579sV2yvbQhtYG25bhJua27Ebx5veG\057RcCtwhnDgcTpxlXHwcktypnMBc11zuHQUdHB0zHUodYV14XY\053dpt2\053HdWd7N4EXhueMx5KnmJeed6RnqlewR7Y3vCfCF8gXzhfUF9oX4BfmJ\053wn8jf4R\0575YBHgKiBCoFrgc2CMIKSgvSDV4O6hB2EgITjhUeFq4YOhnKG14c7h5\053IBIhpiM6JM4mZif6KZIrKizCLlov8jGOMyo0xjZiN\05745mjs6PNo\053ekAaQbpDWkT\053RqJIRknqS45NNk7aUIJSKlPSVX5XJljSWn5cKl3WX4JhMmLiZJJmQmfyaaJrVm0Kbr5wcnImc951kndKeQJ6unx2fi5\0576oGmg2KFHobaiJqKWowajdqPmpFakx6U4pammGqaLpv2nbqfgqFKoxKk3qamqHKqPqwKrdavprFys0K1ErbiuLa6hrxavi7AAsHWw6rFgsdayS7LCszizrrQltJy1E7WKtgG2ebbwt2i34LhZuNG5SrnCuju6tbsuu6e8IbybvRW9j74KvoS\053\057796v\057XAcMDswWfB48JfwtvDWMPUxFHEzsVLxcjGRsbDx0HHv8g9yLzJOsm5yjjKt8s2y7bMNcy1zTXNtc42zrbPN8\05340DnQutE80b7SP9LB00TTxtRJ1MvVTtXR1lXW2Ndc1\053DYZNjo2WzZ8dp22vvbgNwF3IrdEN2W3hzeot8p36\057gNuC94UThzOJT4tvjY\053Pr5HPk\057OWE5g3mlucf56noMui86Ubp0Opb6uXrcOv77IbtEe2c7ijutO9A78zwWPDl8XLx\057\057KM8xnzp\057Q09ML1UPXe9m32\053\057eK\053Bn4qPk4\053cf6V\057rn\0533f8B\057yY\057Sn9uv5L\057tz\057bf\057\0570gBJAEoAnQCeXE5TQ29sb3JTcGFjZaIAnwBNXE5TQ29sb3JTcGFjZdIASQBKAKEAoldOU0NvbG9yogChAE3VAKQApQATAKYApwCoADEAqQAtAKhaTlNUYWJTdG9wc1tOU0FsaWdubWVudF8QH05TQWxsb3dzVGlnaHRlbmluZ0ZvclRydW5jYXRpb25bTlNUZXh0TGlzdHOAIIAigCDSAFEAEwCsAK2ggCHSAEkASgCvALBXTlNBcnJheaIArwBN0gBJAEoAsgCzXxAXTlNNdXRhYmxlUGFyYWdyYXBoU3R5bGWjALIAtABNXxAQTlNQYXJhZ3JhcGhTdHlsZdQAtgC3ALgAEwC5ALoAuwC8Vk5TU2l6ZVhOU2ZGbGFnc1ZOU05hbWUjQCIAAAAAAAAQEIAkgCVWVGFob21h0gBJAEoAvwDAVk5TRm9udKIAvwBN0gBJAEoAaADCogBoAE3TAFAAUQATAMQAyQCIpACCAIEAgwDIgBiAF4AZgCikAIYAhQDMAIeAH4AagCmAI4AmXk5TT3JpZ2luYWxGb2501gC2ALcA0QDSALgAEwC5ALoA0wAqANUAvFxOU0Rlc2NyaXB0b3JaTlNIYXNXaWR0aIArCIAqgCVcTHVjaWRhR3JhbmRl0wATANkA2gDbANwA3V8QF05TRm9udERlc2NyaXB0b3JPcHRpb25zXxAaTlNGb250RGVzY3JpcHRvckF0dHJpYnV0ZXOAMRKAAQABgCzTAFAAUQATAN8A4gCIogDgAOGALYAuogDjAOSAL4AwgCZfEBNOU0ZvbnRTaXplQXR0cmlidXRlXxATTlNGb250TmFtZUF0dHJpYnV0ZVxMdWNpZGFHcmFuZGXSAEkASgDqAOtfEBBOU0ZvbnREZXNjcmlwdG9yogDsAE1fEBBOU0ZvbnREZXNjcmlwdG9y0gBJAEoA7gDvXk5TTXV0YWJsZUFycmF5owDuAK8ATdIAagATAPEAbEYOAAEBCACAEtIASQBKAPQA9V8QEk5TQXR0cmlidXRlZFN0cmluZ6IA9gBNXxASTlNBdHRyaWJ1dGVkU3RyaW5n0gBqABMA\053ABsTxEBB3tccnRmMVxhbnNpXGFuc2ljcGcxMjUyXGNvY29hcnRmMjc2MQpcY29jb2F0ZXh0c2NhbGluZzBcY29jb2FwbGF0Zm9ybTB7XGZvbnR0YmxcZjBcZm5pbFxmY2hhcnNldDAgVGFob21hO30Ke1xjb2xvcnRibDtccmVkMjU1XGdyZWVuMjU1XGJsdWUyNTU7XHJlZDBcZ3JlZW4wXGJsdWUwO30Ke1wqXGV4cGFuZGVkY29sb3J0Ymw7O1xjc3NyZ2JcYzBcYzBcYzA7fQpccGFyZFxwYXJkaXJuYXR1cmFsXHFjXHBhcnRpZ2h0ZW5mYWN0b3IwCgpcZjBcZnMxOCBcY2YyIGF9gBLTAFAAUQATAPsA\057wCIowCBAIIAg4AXgBiAGaMAhQCGAIeAGoAfgCOAJtIASQBKAQUBBl8QE0FLVGV4dEJveEFubm90YXRpb26mAQcBCAEJAQoBCwBNXxATQUtUZXh0Qm94QW5ub3RhdGlvbl8QHEFLUmVjdGFuZ3VsYXJTaGFwZUFubm90YXRpb25fEBFBS1NoYXBlQW5ub3RhdGlvbl8QE0FLU3Ryb2tlZEFubm90YXRpb25cQUtBbm5vdGF0aW9uAAgAGQAiACwAMQA6AD8AUQBWAFsAXQDQANYBSQFkAXgBjgGhAbsB2gHhAe8B9gIJAhUCIwIuAjUCRwJaAm4CgAKFAo8CsAK3As8C2QLsAv8DBgMaAxsDHAMeAx8DIQMqAywDNQM3AzgDOQM7Az0DPwNBA0MDRANFA0YDSANKA0wDTgNQA1IDeQONA5YDngOnA6kDsgO9A8YDzQPSA9sD6gP3A\0578ECgQTBBUEFwQZBBsEJAQmBCgEKgQsBC4ENAQ7BD0EPwRIBFEEWgRjBGwEggSJBJYEnwSnBdMF1QXeBewF8wX6BgsGFAYmBjMGNQY3BjkGOwZsBnUGegZ8Bn4GgAaNBpQGlgaYBpoGoQajBqUGpwapBrEGxAbLBuAG7QbzBwAHFQcdByQHJgcoBzUHOgdAB0IHRAdGE5ITmxOoE60TuhPDE8sT0BPlE\057AT\057BQeFCoULBQuFDAUORQ6FDwURRRNFFIUWxR1FHwUjxSgFKcUsBS3FMAUwhTEFMYUzRTWFN0U4hTrFPAU\057RUGFQgVChUMFQ4VFxUZFRsVHRUfFSEVMBVJFVYVYRVjFWQVZhVoFXUVghWcFbkVuxXAFcIVzxXUFdYV2BXdFd8V4RXjFfkWDxYcFiUWOBY9FlAWWRZoFm8WeBZ\057FoEWihafFqQWuRbCF80XzxfcF\053MX5RfnF\053kX8BfyF\057QX9hf4GAEYFxgkGDoYWRhtGIMAAAAAAAACAgAAAAAAAAEMAAAAAAAAAAAAAAAAAAAYkA\075\075)
+>>
+/F 4
+/BS <<
+/W 0
+>>
+/Subtype /FreeText
+/DA (\057\057Helvetica\04012\040Tf\0400\040g)
+/Border [ 0 0 0 ]
+/Type /Annot
+/Rect [ 267.5255 559.2131 325.6696 569.4714 ]
+/M (D\07220241122152819Z00\04700\047)
+/IC [ 1 0.149131 0 ]
+/AP <<
+/N 18 0 R
+>>
+/Contents <eda080>
+/T (Michal\040Stolarczyk)
+>>
+endobj
+7 0 obj
+<<
+/Type /XObject
+/FormType 1
+/Resources 8 0 R
+/Subtype /Form
+/Filter /FlateDecode
+/BBox [ 0 0 58.14413 10.2583 ]
+/Length 281
+>>
+stream
+x…Q»NÄ0ìóCgñyílì”<®¡;É¢@9"âN
+¾Ÿµ"‘äbw,ÏÎìxÄ#¬Ž†š†<ÈÇÑãý¸`w;ú	+:òÒ`ê¸]8±P¬¯„4”‘Îëˆ	kÃÞÄÈÑ¡ÝŽÎòeæ˜UäÔ„ÚµÁ°c‘Î4šª?ã&¡¶ÆZËH=ØØHÎŠœQfk|ã<Ò»”²ã4àêtÑUõ¥ARžßtVT§#>?ævÐðªžQ„ÆÒ=ö©ìö¿ÉÕKÙfE®¦ÜnIèÙ™ºÒH¯‹Jõ‡
+æ(Ö¹¿U¼uFDâªRm÷ßßÉbòÍP²™5ukes•,~îã‚å>'P•ßN‹sí
+endstream
+endobj
+8 0 obj
+<<
+/ColorSpace <<
+/Cs1 9 0 R
+>>
+/Font <<
+/TT3 11 0 R
+/TT1 15 0 R
+>>
+/ProcSet [ /PDF /Text ]
+>>
+endobj
+9 0 obj
+[ /ICCBased 10 0 R ]
+endobj
+10 0 obj
+<<
+/Alternate /DeviceRGB
+/Filter /FlateDecode
+/Length 2612
+>>
+stream
+x–wTSÙ‡Ï½7½Ð" %ôz	 Ò;HQ‰I€P†„&vDF)VdTÀG‡"cEƒ‚b×	òPÆÁQDEåÝŒk	ï­5óÞšýÇYßÙç·×Ùgï}×º Pü‚ÂtX€4¡XîëÁ\ËÄ÷XÀáffGøDÔü½=™™¨HÆ³öî.€d»Û,¿P&sÖÿ‘"7C$ 
+EÕ6<~&å”S³Å2ÿÊô•)2†12¡	¢¬"ãÄ¯lö§æ+»É˜—&ä¡YÎ¼4žŒ»PÞš%á£Œ¡\˜%àg£|e½TIš å÷(ÓÓøœL 0™_Ìç&¡l‰2Eî‰ò ”Ä9¼r‹ù9hž x¦gäŠ‰Ib¦×˜iåèÈfúñ³Sùb1+”ÃMáˆxLÏô´Ž0€¯o–E%Ym™h‘í­ííYÖæhù¿Ùß~Sý=ÈzûUñ&ìÏžAŒžYßlì¬/½ ö$Z›³¾•U ´m@åá¬Oï  ò ´Þœó†l^’Äâ'‹ììlsŸk.+è7ûŸ‚oÊ¿†9÷™ËîûV;¦?#I3eEå¦§¦KDÌÌ—Ïdý÷ÿãÀ9iÍÉÃ,œŸÀñ…èUQè”	„‰h»…<X.d
+„Õá6'~khu_ }…9P¸IÈo= C#$n?z}ë[1
+È¾¼h­‘¯s2zþçú\ŠnáLA"Sæödr%¢,£ß„lÁt 
+4.0,`€3pÞ  „€H–.Hi@²A>Ø 
+A1Øvƒjp ÔzÐN‚6p\WÀp€G@
+†ÁK0Þi‚ð¢Aª¤™BÖZyCAP8ÅC‰’@ùÐ&¨*ƒª¡CP=ô#tº]ƒú Ð 4ý}„˜ÓaØ ¶€Ù°;GÂËàDxœÀÛáJ¸>·Âáð ,…_Â“@ÈÑFXñDBX$!k‘"¤©Eš¤¹H‘qä‡¡a˜Æã‡YŒábVaÖbJ0Õ˜c˜VLæ6f3ù‚¥bÕ±¦X'¬?v	6›-ÄV``[°—±Øaì;ÇÀâp~¸\2n5®·×Œ»€ëÃá&ñx¼*Þï‚Ásðb|!¾
+ßÆ¿'	Zk‚!– $l$Tçý„Â4Q¨Ot"†yÄ\b)±ŽØA¼I&N“I†$R$)™´TIj"]&=&½!“É:dGrY@^O®$Ÿ _%’?P”(&OJEBÙN9J¹@y@yC¥R¨nÔXª˜ºZO½D}J}/G“3—ó—ãÉ­“«‘k•ë—{%O”×—w—_.Ÿ'_!Jþ¦ü¸QÁ@ÁS£°V¡Fá´Â=…IEš¢•bˆbšb‰bƒâ5ÅQ%¼’’·O©@é°Ò%¥!BÓ¥yÒ¸´M´:ÚeÚ0G7¤ûÓ“éÅôè½ô	e%e[å(ååå³ÊRÂ0`ø3R¥Œ“Œ»Œó4æ¹ÏãÏÛ6¯i^ÿ¼)•ù*n*|•"•f••ªLUoÕÕªmªOÔ0j&jajÙjûÕ.«Ï§ÏwžÏ_4ÿäü‡ê°º‰z¸újõÃê=ê“š¾U—4Æ5šnšÉšåšç4Ç´hZµZåZçµ^0•™îÌTf%³‹9¡­®í§-Ñ>¤Ý«=­c¨³Xg£N³Î]’.[7A·\·SwBOK/X/_¯Qï¡>QŸ­Ÿ¤¿G¿[ÊÀÐ Ú`‹A›Á¨¡Š¡¿aža£ác#ª‘«Ñ*£Z£;Æ8c¶qŠñ>ã[&°‰I’IÉMSØÔÞT`ºÏ´Ïkæh&4«5»Ç¢°ÜYY¬FÖ 9Ã<È|£y›ù+=‹X‹Ý_,í,S-ë,Y)YXm´ê°úÃÚÄšk]c}Ç†jãc³Î¦Ýæµ­©-ßv¿í};š]°Ý»N»Ïöö"û&û1=‡x‡½÷Øtv(»„}Õëèá¸ÎñŒã'{'±ÓI§ßYÎ)ÎÎ£ðÔ-rÑqá¸r‘.d.Œ_xp¡ÔUÛ•ãZëúÌM×çvÄmÄÝØ=Ùý¸û+K‘G‹Ç”§“çÏ^ˆ—¯W‘W¯·’÷bïjï§>:>‰>>¾v¾«}/øaýývúÝó×ðçú×ûO8¬	è
+¤FV>2	uÃÁÁ»‚/Ò_$\ÔBüCv…<	5]ús.,4¬&ìy¸Ux~xw-bEDCÄ»HÈÒÈG‹KwFÉGÅEÕGME{E—EK—X,Y³äFŒZŒ ¦={$vr©÷ÒÝK‡ãìâ
+ãî.3\–³ìÚrµå©ËÏ®_ÁYq*ßÿ‰Â©åL®ô_¹wå×“»‡û’çÆ+çñ]øeü‘—„²„ÑD—Ä]‰cI®IIãOAµàu²_òä©””£)3©Ñ©Íi„´ø´ÓB%aŠ°+]3='½/Ã4£0CºÊiÕîU¢@Ñ‘L(sYf»˜ŽþLõHŒ$›%ƒY³j²ÞgGeŸÊQÌæôäšänËÉóÉû~5f5wug¾vþ†üÁ5îk­…Ö®\Û¹Nw]Áºáõ¾ëm mHÙðËFËeßnŠÞÔQ Q°¾`h³ïæÆB¹BQá½-Î[lÅllíÝf³­jÛ—"^ÑõbËâŠâO%Ü’ëßY}WùÝÌö„í½¥ö¥ûwàvwÜÝéºóX™bY^ÙÐ®à]­åÌò¢ò·»Wì¾Va[q`id´2¨²½J¯jGÕ§ê¤êšæ½ê{·íÚÇÛ×¿ßmÓÅ>¼È÷Pk­AmÅaÜá¬ÃÏë¢êº¿g_DíHñ‘ÏG…G¥ÇÂuÕ;Ô×7¨7”6Â’Æ±ãqÇoýàõC{«éP3£¹ø8!9ñâÇøïž<ÙyŠ}ªé'ýŸö¶ÐZŠZ¡ÖÜÖ‰¶¤6i{L{ßé€ÓÎ-?›ÿ|ôŒö™š³ÊgKÏ‘Îœ›9Ÿw~òBÆ…ñ‹‰‡:Wt>º´äÒ®°®ÞË—¯^ñ¹r©Û½ûüU—«g®9];}}½í†ýÖ»ž–_ì~iéµïm½ép³ý–ã­Ž¾}çú]û/Þöº}åŽÿ‹úî.¾{ÿ^Ü=é}ÞýÑ©^?Ìz8ýhýcìã¢'
+O*žª?­ýÕø×f©½ôì ×`Ï³ˆg†¸C/ÿ•ù¯OÃÏ©Ï+F´FêG­GÏŒùŒÝz±ôÅðËŒ—Óã…¿)þ¶÷•Ñ«Ÿ~wû½gbÉÄðkÑë™?JÞ¨¾9úÖömçdèäÓwiï¦§ŠÞ«¾?öý¡ûcôÇ‘éìOøO•Ÿ?w|	üòx&mfæß÷„óû
+endstream
+endobj
+11 0 obj
+<<
+/Type /Font
+/FontDescriptor 12 0 R
+/LastChar 33
+/ToUnicode 14 0 R
+/Subtype /TrueType
+/Widths [ 1000 ]
+/FirstChar 33
+/BaseFont /AAAAAD+LucidaGrande
+>>
+endobj
+12 0 obj
+<<
+/FontFile2 13 0 R
+/Descent -211
+/CapHeight 723
+/FontName /AAAAAD+LucidaGrande
+/Type /FontDescriptor
+/ItalicAngle 0
+/StemV 103
+/FontBBox [ -1067 -737 1641 1162 ]
+/XHeight 530
+/Flags 4
+/MaxWidth 1640
+/StemH 77
+/Ascent 967
+/AvgWidth -490
+>>
+endobj
+13 0 obj
+<<
+/Filter /FlateDecode
+/Length1 9208
+/Length 4966
+>>
+stream
+x½ZxTE–>U·óîN:IÈm.áuá%&ØBçÑ(D° Ý ØÈ#’€òD4|€ŽÌŽŽâêÎÎìŒrÓ‰cG…duñ“]]‘õ9º€:>¾YÙaf™otèýëÞÛÉdü˜Owo÷©¿êœ:§N:U}ïMZ7nj$µ“D¾¥¡æU¤_Ê«€ò•ëBÍFÛõ°dåæVÙhg§¥þrUóëŒvA?‘mÚk·˜ú£ÐùšCaCNBFF›MŽnZ×z«Ñv}	L_»a¥)U„vêºÐ­æøôÚòúÐºF£¿ò$p\ó†–V³-úMoÞØhög~"ëAbàr’17q1²ÓdÚF”rÊ6Íä`–º«æ•7ä¸ÿÀœ˜®ž¶—^xâÔ$ÿÙÍrÚ\óÑÌÐí	ì¦½pÎ‡9<»ùl­Í•”©¸xŒnVct#èzÐbµ:Ì9dqjãuÄølî†žÊgqw”©¿}ž_æåh”Ò!Èì Îv±ÎhI©'Æîî¶VQu6ë$;ˆ³;Xl©ìNïbQ®¶?ÏÚ`ö$ÛîYÅNž*6üÍ·PlÛ^èÌÙVº­b›´m{ñÇÁÚ|ŠuÍ(Ön@qÓúBçëÛnâ7­oÛXÒº©À1üÆ5(V­FÑØTà¼¯ñ@ã±F©±©ãæ’â–Â­µÅ®- Þ+-’æadû!iù@œ<RU4+»ª7Þ/UF³ÍJw†µÊW%M$&M–¦`UTþ%ÿJ~=ÌÕÿ ûpsåïwO™Y%0ªŒVP)(Ð+ïE§U™•	“ÌŠK1+ÃŠÍJv®^9ÍE…·ó[…{Õ*o%ˆ#´×£v=jYü*r‚nIhÕ£UOœÏä*¤R^	ÌNåSD°ùd+€#ÁŸÄ§DG–Ê1@^aU/;Ë>ŽJjfµÌ¾$Æ~Ëþ[h±Ó&~aâ™ø9ûL„}
+´ ?¢ü_ÙÇÝYp½zŒ6£¼KˆØƒlŸnð÷±û)Š{iÀû€bÀ{Ùý˜r_šŒšQ¶»6ºÏ¢ÆØâè^WG÷˜ÑÝ&©H°ªh^QUuÍÊt§ì,WG‹ç²o¾?úþÈ=Ÿ–”TýèaI}äa‹úðþLõØÛ»/UÝK? ýp?WÚ/©ö³ÇöÜß·_zAºRš+&'ÍvpU¤Dm·=·ªô°„M@§D)]"MGÔäê<iMy@>Eš&'¤©&VHèYÑ‡&v!²Gq~&z(ùóQ´/]Á?Œ§§À‡QäBŒŸŠîÊ„üdwŸSåït+e"¿Þ‰:°hè<
+—ªmüe~DÄ“¿Èûuüg÷ß_à›ù-b*üs*üfc*|£˜Š^zx0a4ÍÌÒ­ßV¤W–GG×+Ku½ê¾LWeŸ‡²Ï¥1 N|"ƒ8ÜS£¹]o|·-·
+Ù¦ˆl;ÄGqY,7wq9jQÂžŒ3d$J±¹J)ûŠ½®/ä)öC;Éž‰ŽqÉ1v2:ÒUU]Âþ“} gÍû&þÊÄ÷L|—½£x‡½­÷{›½‰ìÒúÐdì-ö¦Îü¹º:‹Ç<zEÉŽ›²7tF<Å!Ð‹ü~]ä·ÚÇž 'A= )~Šý$šïÀ2°{Ø}ÀÝ&F€"­¯‰Þ…c‚-‰¶K€†è])€EÑ]F;ø¢B¶ Ú!à*±P1VÝ%`J´O0GÌlO„úÚ¢~-:Åû=™‰ù;õÍŒ.Çð*Ï'HyÑštÐ–SO==¾ž`OsO{OÏ±žS=gz2z†K?ÿÌ¢ÞIS#»SÕ= ¨<{ïä©U÷Þƒ!¡^pÏH¥êžÝ\ÝÝ‘®î¼Ý¢Þ.æïïnŸ7_ØïnŸ]kàô*ÇMÒÇµ¶PªÚwpµm‡nÕc½Í;·ê64vÀ’0-wÂt'f¸Œ»:RÕ;îÌTï6w´wð¾V)-–([òIQ.®eT
+—V/‘®’æSŽä”†K#È*åHv)h•lR6p,p<Ù$ä
+p$ä2p,¹%h$È	ÊYÉÍŸâOóƒdåó¿çO åñÀ^àódãÝ?Ô {¡ÓÒ„.èqÐ£ ÛùNÊæ;xÊíü6Qêþnâ[ù6ì;Ïåy°kãÙ<È8çYÙ9çøíÇIžKƒ¸è‹³ÞNú@'A)8¹m4Ô’¨”Ã¾)†®>åÃ¦X?òAv”
+bäF_7;Ä³>Œ×Å¢¬ø4;È4àQà¿‘½ù`?ä/Bç%P¿Ðuž­cëÙè…Ø
+¶¸œÝÀ‚z{UtXiiu[E³Am ‰mt¬µ@k°Z[`©Ô,,‚VB å r6‘rØ6å86ž²Ù¦¢,bÅàä±|”ÌN!†2…¥¢äLB‰-,JÏO‘*çâ9ÎKE3ŽKyÓ9ÓÖ©ŽŒ)ŽÔÉ©ÂA“cÆf›3AÍ.WsF)Ù£•œ‘¥ÙriNŽ=×š‘™eMMK·J–+"m%É“_¢”_š*/-Í™Ó–#É+•®–ú¤¸dq²¶¢´›Ã>Ì–g)°Ýïdåî	îqî1îÑîQnÙ=Òít¹î<wŽ;Ãê–ÜäöMcZ^=Õ7Ôhù¸¸F›¦ÖÇ$y‘6U­×2|Ëü]ŒÝ Wã1Fš¥3ÆyµK—ùc¬Xˆ;œ½bÞZ}°ãž@§ujÊb¿ ÏB¿&wÆìÔàïâ¬&h—ÖûP§š€:B×£[ûˆ€6UTî zmæBÍ©Ô¨ƒ¯ÁhiÕá¼¬kÜ¯6ÁÒÊ½ÁºólU%4à°W;çÅWK°-¸ÌfŒo÷ÆøV˜á;†6“Ô‹I¼1é*t•|¢kkKÊ†¨´´‚Éôr°T¼u WÂ TE<t¸ ÐÝn1t¡˜’–Ü^0ÈÓ6m
+­•ÕúUÕŠ4I’P0-
+`1¶]ö®©‹±ÛØa@›íÜnÀNî0àN:¸Ë€]tp· sf¸+¹Lçr·—0Ë€Ùx¨6 Æ€Zêð0Ç€+ n˜[KW†È~ß¢šz-}È·L+QÐxhX•JU©OF¯PY¢4dŒÒ2‹ÄÅß×ËÏõs›âzèÜ»‚÷].ñì%Èò]ŒÝ#„5~Y|oüKê£&*ˆWÇÿbH³;ã;è$§£ÔCOÑÃtõ#t˜zéçô1ê/£öý€V@ûIú1u ÿ‰§i#øçÈ_ÚfãðÎÒYÚÏªipðõ ¬<8˜ùWÛŸÆK†ˆ¢í´oâ¿¦MøüA.è¹õ <ÿa§i{Va>¦û¸/þ›”£T(ÝŠGž–"\‘Ÿ¶PXz$þ;äINš?ªã¿ÏÒ®oë·c'®^ÚÃ2iâ6…®†¯5	Á@DÏb+1—øìÇjtã³ãî½°gjh%üN'#[y”"Þ5àŠºU¯ñ63öCÚŒÜ4s9ñRäÍ•ñÆø–øã‡bõbfEZ?£½l?<XA×Ñ5üU<Ø‰Ö´¯¡yl³Ñ£°}‰>J²0w•d0DŽ‹+áŸÅŒ¢¹·à¥qÅ/KÔØ>ü0Ÿ¥Wè%Šéþ<Bû(BíˆC+ò{)ùàûL¼–0ú}¢ç°ðü|ŸåÔ€ÜÃ…œ…ùœHØ˜ò–¾÷Íw7áŸØûG¤Eã:—¨½†•4vC'¢±	ñX‰•=«ï±~G°j#×²k’Ò—õµýgÑTáE|f|bÿït-màÝ¸a¹zç‡JÖ~n"“‹è›•”¬|—¼ßŽ=t„`°ƒ®§ÆœAÁñ$¢™r·ŽbÕ~‰ñ¶á³}ˆN½Èï#ˆÓVZHÕ´ëxû£	{8Œˆg2ÖçœbC]!Ø=†UÙ ­’ÌUª2D|†¸RNÌtbd~2w]ÜM´à¬‰ÞeyÈè]äÄSô,Î’Yl\Ûí¤õ4ÁüÇ³hî•îËfVU^:ã’éÓ¦N™\1ib¹:aü¸±cÊF+£\réÈÃ%ÅEÃ
+ùy¹öœl›5+3#=-5Å"á~¾œiEµ~ï­¸6ˆßÂ:Å.kÖgæWh”çt)¹ò´ŠÀD³—–¢j”_¯àž<•-UÜe&•Ùï‚ò|§ìÕ,eø*óBamÜ"¿K±¿íLÊ0«•Ôú].§ÆËð¾óBrX³ûÀ‡@çÌÕÈç‹T	&Uº(ùµ‘‰&nE‡p²;ª›XÄÞe-®­Ó¨ ‹¬iäÝÎTÂ´q¸5.³£¦[£
+ü^cùsÌÇ”!ÔNUoxâ¯FDÃÁó1=cDÔ%GäÈ"î4§Ë¥;;‘…þ®¬ÌZ¥¶1³ÀM3Ô•™N–``Yš»˜uÓ+Üê‰;îtÂ—'Üõ
+Z£yvQQê7HòÏKð¼çBAÍèDè¦×˜>¦–Z«¥NÈ«5OH£ÝrWydîøWUkX	‡®ókRNu‘TæmjÐ†×û–‚'@Á&Y,w^ˆÅ“½MrmÑ7ˆR©ƒê@~¸©1(Ò„•:È2jý»\ýN<’øwyµ\U³AÝ¶õ×N)â-Z-‹f$²KÖàQä©KôAM,—#^£Á˜wMX±Šä²éÙ87¬/ŽgwHÖÚW¬AÌðíIä¿+b×¬_¹°:XhŠÝ!,(\#¦²š€ÙÝ¨Ou>5ä«¸í$‘ý´ÚKýÞ&Å‹xš" Ð—Êëº\Z±*#¯p1†÷"2øãfnì	§ÊàO­æiÐô5ÀˆžP]Àd™ ±`4O°.“2@K+Û•2I‘#ÂhZ™V Ú]ÿYÿÄòúE~oÈNôäµþËO9O£Ž½›¡O¤â´’,VêYÐ$â#Š`ƒ±5såÑÕì¯[}­Èùtç(s‚‘ÈEž	FB±xû
+E¶+‘.«5ÒìÊúÎgà?·Û©ÍÙÐìÁ&6‹,òmîàó.Ë3Gn
+ƒïlÅUétåÂ´Ñ'ÇÐbsŸ!ã‘÷bŸEì_`ÆVœHNyŽ8^b8œš½RlSx²Ä}°CxÃzýÇ\î;E
+”yW/6ätaH=aÄ¹·ÐäÂˆË%öÐî˜‡V ¡µ/ôm™V8£ä©P±vA!éOHK„¤=!Iª¬U‘xÌÖsâ¯å4Îód>Gr•<¹Jæðß¹a­¿süc¥–ŽˆéË_ë—œ\tA;%QËTñ“àÖ†©º¢ˆ	NÉˆ]‘)š]ÕRjýýNw@¶çâ€dÉd0-Š4µSŽ2qˆR]cnŠmE8TFúÃ*!L*ÊÞHÐÌ¾ç‡®¢w¸)¹ŒY`ãŠI"vûÖiÄ#7OS}Ud»ñ§¥”Í›
+k£Gl^@Ë?vZözÉ9ký2Ž!lÛ…zEöÊMbÕ59X§Ÿ§'Ø±ø©`8ÿüH4tqšù,GØÌ=a†¡¾ÁŸ¨-òßæÜ˜ˆ¿Š•×Ç(¿¤âLŒÅ;bT7¢g“nXqC¹,{W×a@4–”ƒ1Á…Ú5åÈM‘ú~% ~Iæ†#²Hþ0¦¥#‘@òu±ç%^Õ¸4OÀ™¬63açZa*è	ÀÂÓPgUüüåõ8©Æøü8lÛëèubcºýØUýbÆb"¤§ðø¶ÕE¦ÏKás`äË+ÈÕv˜D"Âæb¿‚4DœÌÃlãÏ`†ÇdÄH¨`âÞk÷A è÷^Å¥ˆÈê0Ôuˆ{â”Âß¿=ÂË“~Cóx»\pð{Špèb"¼â¢"¼2éé€‡áóJáÆ¡#¬ñ1ßãCê1Bê"¤«„ôÆoiSÒQxµî5é!]ó=…ô¦‹	éÚ‹
+éº¤§Bº>¯!Ý0tHÿ/’¶y@„oþöoLú'[àíF=Â­ßS„7]L„7_T„oIz: Â·Âç[D„·üÿExëÆ6™þ¦_xÃ¯?‚YÁ´¢&þ“ÁàÉôSpð„„7øàÏ$iTðl*· Š×Þ|M/¦LvåºrËP0<~ã‘Ú¿iO¡¯Éci‡&´(ŽÑÒýRzÂøÏ¹"F.l‘åõ”€h§£Ì º€vðK>¨N¡_Q	ýÄ¯¯vâg¢/Jh<¨
+4 ­mÝú;ÐÏ@½ £ ÛõxƒÂ0”Tñ\²P«úåãý†ÀBøÊróª&OÉÍà’ëñ™>c6ÃsåeTšcÆ´©Ž‚–ê°ˆyR'³Ÿ;Ãìò•³úú½§ŸíŽ¼}§g…¤‹¾A?ztA[ î²ûî¼ÿ+__ôóû®X{XÄW¼ÏíC]3ž…ÿdYZÙ¸®q}«Þ‰áŸŒuI…¿T-®:õªM+W‡CWl­ë¯$+GøO¢áqó’uÿ³hÿ/¦-Æ2
+endstream
+endobj
+14 0 obj
+<<
+/Filter /FlateDecode
+/Length 222
+>>
+stream
+x]½nÄ „{žbËKqÂ¾!Eä"?Š“À°XHñ‚Ö¸ðÛˆs‘RlÁÌ|0¬¼O…ò£1ƒä×¸±E˜p$ú¸`óqjš]L²Àã¾f\ò” ò½ kæN.NøPµWvÈf8}^Ç¦Œ[J_¸ eè„ÖàÐ—ëžMz1‚lèypÅy?ê/ñ±'„Ò¨ýO%®ÉXdC3
+ÕuZÝnZ ¹ÖLþH^z­êxï]Ëÿ:­_¼W²siÓöÐŠÖð¾ªS}°Í7®fpæ
+endstream
+endobj
+15 0 obj
+<<
+/Type /Font
+/FontDescriptor 16 0 R
+/LastChar 118
+/Encoding /MacRomanEncoding
+/Subtype /TrueType
+/Widths [ 313 0 0 0 0 0 0 0 0 0 0 0 0 363 0 0 546 0 0 0 0 0 0 0 546 0 0 0 0 0 0 0 0 600 0 0 678 561 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 525 0 0 553 0 318 0 0 229 0 0 229 0 558 0 0 0 0 0 334 558 498 ]
+/FirstChar 32
+/BaseFont /AAAAAB+Tahoma
+>>
+endobj
+16 0 obj
+<<
+/FontFile2 17 0 R
+/Descent -207
+/CapHeight 727
+/FontName /AAAAAB+Tahoma
+/Type /FontDescriptor
+/ItalicAngle 0
+/StemV 0
+/FontBBox [ -600 -216 1515 1034 ]
+/XHeight 545
+/Flags 32
+/MaxWidth 1550
+/Ascent 1000
+/AvgWidth 444
+>>
+endobj
+17 0 obj
+<<
+/Filter /FlateDecode
+/Length1 9216
+/Length 6048
+>>
+stream
+xÅZ{|TÅ½Ÿ9¯ì{Ï&»Ùì.ÉÙe“r6Én{òØð t%		D$à£(±µ‚-ÖV¬å£ÜúhµO6€ÁFXå¶*¸(­­mj­n£~,ò¡H’û›9› ê}|úÏÍœùÍû÷øÎofÎIÏÍ›;	õ")«×·v#D;$GWoéñjù4B¬nM÷ÚõZÞ õüÐÚ›n[£åm¤?ÒÙÑÚ®åÑEHCP åq)¤¹ë{nÕòÖãÖÜÔµ:U/þ‘Ô¯o½55?"yï†ÖõZ{ÿ0ÉwwmêIå÷BZÓ}sGª=n~úµºËžhš²‘À )h9Hò ó2-!õ<ó[
+Úž[e­øyt´øÉç§âå´[û¢t¬ÖäÕÕBV#húéðX3B¦5_”^¸ÝäEd¤Ëƒ­¿U¦ã; B„§q7DEñf´ŠÆ-Då¸k `FHÄ]	§'4ˆ7°³}»+Ýx#ô,†çˆÝƒxâŸ!
+È
+Ï(ÄU·AäÆ“¸!1%;tˆÕ‰ôJ\()M¹ù0øÕ™’õ|-ú"³¯p¹Éì+š&D‘öhÐHAwŠ½nÂ<žphD[Âî %mó.› Ö&!Zµ6aÉ§Äš„ÞL‰Ö	¢#Q¢µéHÒªŽD¶˜ìH¸]™©5Q¿4Õg^4E¸4	[2(»­F3árU¢ H[Ô'V¬ÔˆÈœPqe&®)ëA‹õ ínxöB3âv°K;PÇá9L(Üžèn§×&2ìtÚDffŠ mžª6¢ÚW€0XhÉ¼„3‹sF p1(Æ ôÁ‡íÒ‡'‹%ïŽ€#0~$ÁfI•<ˆCj†´v)Pi‚<Æ!\‚,PZ
+©ÒY¸$!JÊó¸ T®ë_e”·§æ†NœŽJovK½oâ7!‘NãîÓøÕßJ¯þ&Rþ*6þºæ×Ìàxòàõ¶PýI¤’“˜‰	oBI,It'zûjâxb8aH&>MÖJÍHªÁÖÒ
+¦~ùªåLù‘B©ë~ìÈ³G˜ð!‡ø%:ì”^8œ)~Á!=h™tðÐté¹CAiâ¡²ˆ4ˆ7)³£A©âÜè\i^Ô'UG³¥ªè2©¢1Z”‚%íRIY©TVÚ(•–åHÇK‡K?-eÇ?ØŸ· 48><°_ôCú±bÙ¯·†ö»HÇ7àáTýÃ¤A¼Áñ}w:€¢AÄpoÐ§‡º€•µÐ­{Mïš}kÔ5Ü³G:¨”…íÐ«ëÁm2]»q÷ýxÛ®Çv1½û0j[Ò–lc•ÖîVF¼Ö{íîkÙAÜ£<gJöÒ Äv›TdÏ“d{D*´gH.ø¤€y£€$l]”õVK’=GòAêµWH¹—InÏ|Éã®Ü0ŽúeØ+¥t»[²Aì¶cÅ^YB¶bøà(îÂÛð³ø~‚Ç±ÁŠ°Pu¡mèYt½>AãÈ`Ð‡%+ce™7˜7ØqfœåLæÏEX&‚Qd	¡·š^‡ê«ÔiCU¿>(×©íËª¾}ß}ÙêCuËšÔÞìæA´iR±ŠïoVuu)É6õÀß¦•©B¬³Uü5›HÆB2ª•ÐVVí±NÕî¯‘7‘®“ÆÐÂ¦T7mJ5ÑªÐæÉ¶—djhJÜ##èEK !µ!.ŸjSOÏ×DGÝD’ÁÏÆ:á‚ÐÖdðÞBŽ`ç?åOp[¹8{)ÿ`ü/c·Žµ5³?DÓ ÉCètE¿töCè%JoA	”D¯M–â.ô=ôz½æš£GÑO‘
+Ù=@Ý×à­h7"¥O §Ñ/Ð zi»ÓD¯Kÿg§Š_fìXãà#dbNàMø~yª‚ßÑËºî€=>¿!àqf!eV2¯3÷2]LX‚¹¤K²'Ù£ÅðK¢·Ðá¯ü.üOüOÔƒþz{Ÿ9Š~†~Œ¾v @ê'!×…¶£ï ¢}_î-ôñ6î³+JÑÏÑ=è:ôÐô+ÐãÔ õ{`,„î@äFß’êñúQŠúO¸ë™ ­ï1ÇØ*fˆQÙ Ã±CøÀÛ–C-ðkþƒÖ :ÐÇSè'hJHØÈJ û$l„ß#è<úó´ßŒ6³{ÙYP7„æ¢6ü¬ƒÞt?ŠÞE+á×ã]ü2hzrC¨Ð6Ä½–•öw´
+-…ø~Ž;È¿‰îDë!¾‚Ö+sçÌŽ”‡Ce¥%ÁYÅ™3ŠäÂéÓòórýS}^)'{ŠÇíÊrf:ìé6Ñj1›Œ½.Mà9–Á¨«YÕMý®4Ùãóùšg¤òî+ó*›'~æSQú<W6êŸò¥|ö—ò9“ù«UdWkýÕ5dà~Tû¾Š2TlW™g\3¥8‰µ¯óÇnP]Õí--Ð£Æ/zÕÚO)V(ÃýFCµ¿ºÃ0£õŒ@‚¶Ýý¸v¦S›ÝÏ yF‘š.«L^ŒÄuª²³ˆ5—j`WÚuy‚nZ#Í(…U¡ZM£ózoP•Víôö%ûvŠ¨­E6µûÛ[¯kRÙVPj?bóbà³!!±¥Ó«r0/}x ÄëôöAž4k§¿z}m9ë«›¶û’5Ò˜j“ÕùÐsþíïyØ¾XÖ^’íëÛîU÷-mº¼ÖGÚ477gÍ(òöÅü0QÍŒ¢Øº*ÐtV`FQžPM{Ë:ÂËºVÂgl·ogåuå6u‚aZÿ·V}}±v¬½µL£W«J#MPãJ¢oTWÓœ*J5€ŽÖ´Ô4ƒ®	c°õUCmÌßZ$8,iI•@Al¢ÒKø\¨*-ªwµWEËšüÐ¹œ<:ÊQßêr‚cÏ(ª[r©—Êç‰~oßçHÅ-þ‘¿Ž/•´¦J„<ñsD*kýµ-}}µ~om_K_ëàxo›ß+úûúëêúºc-0ëØ˜¡üùµvW³*¶tâÙ {‚€ÚeMQÏrhÙ%Y`„ÉfÏåÁßÂT¶@MpRQÑò¦f(²‰Ð@k) ·lœRÑQ&"tŠôù:w*¨ì®ö.mÒò^ÔæI % ƒ=ZHMr¢Æ±œÔôNÔLvoñƒqöÓ•CÕåOþYÅÌŒXçlgþÕZ½šQÝÄzx K(ƒ+½BuÊ@È}`–ã~U”U¾)é©höŠ6ð Äzþº¥+›¼±¾Ih%)I	 êþÖÎ¾Ô# ÿúRrÒNKz'h¼·m€þZw÷ãëÕÚs>¯ÏæO÷F„U¦º±)Å•b*ÀáTõûñŽ¥ý
+ÞÑ°²éœQ¼;›fª[ªš›gè@qL/\v?D+¹ëQÄEÜëãçøõhwÄ4›»	Íav¡l|
+.§Ð.nÚÁü9 íe/ÂõÁ ÚÖ¹AÈ{Ñ5©È|%À…
+û¥rîKy¸kÓ¥}¥æÿV ]ÏõÐØ@;éÞMÀEêR° +9»Ñ !	îÿ¿Ã/2W1'Ù\®’·ñ?–	GÒzÒ.êë¯‚‹4L#B³ØŸ‘8öÎ1ú˜Uì³ùlyðÀÐêB/¾ )‚èi%3‹¹Ÿyzg+z\Ål#z"wŒ“-Ìä’@Ffc_™¹ôu¦”™u .žãáŒü'Èˆüè%ÅQŠçcx‘ñv?ÛQæ[äˆù8ýàø§J–ÅfEx8éß!Ö`õ‰p`Ðàø©ýf33ˆO÷›L”xk¿ÑH‰a(HÕ0´¡ÄE¥Èh
+y|û„¤À"é,ˆ¤§Iº	&ÒT0‘žÂàø»0%’f[X¤Žåñ‘’AÑ‘èˆ,ÇgÇ±Èø§261½$˜ŽCprÈŸ–ŸïŸ*¤	‚ÃžéÌÌ,	†8ãGÿ8÷>‰ã(;++'ç†Æ†¥œÌoö+nd>ë»ß‰wàñæ±;/\ôî#?x·nq}ýÕ‹?üîÞ“W5kü¢ñ?qvþpMÎF³±tÐa2ß¦Áñ³û	aœ èñ¬²šÔÚŠuÅ–bW0¨è‹âª
+6ã•|£n•meú*g£«1»azCI<ÜnèpÞäkÉ_]´º¸=tCdkú–¢MÅÒ4‡©LŸ.ä°ÏÍd<ƒ9ä5«ÜQ [}¥&±—kêfæ q’Z‚” Z-…ž¥æbL±QMûär9Ë·/7™Ëä’;k¦ÅÎ¥fÉ#0sr©Y jX1[äRåNª¿¤$ Ú'Ùx$2b‹DlP@m’îŒ€M¨Åp)1ƒfg(”A3ZL‚§;••†Âe4)	Â¡NHsdB‚Xùž[Öïœ?_ÚVzÍ¼)ÖNÝ8¿¡éñoÜùðØ‡]•hå]ßØ°nìå×>ß¼á›÷Œý'·¥ýž[×,Z3ÝVa«¾otãu7•gå„ÿmívuÏØ©ªyO^wÛk‚òðÍ?~ó©öWÂÂÜ_Ü{dl1ãçâÞâOÀú3 á~x¿CP|V‘ˆž0[gà¥‚ G˜åtHÇrz”†ýÓsD3z½ÉhKäSÇÄSÇP4MD#I1	O–=Ê"Ø<TÝô¿ÃœeX½AØž†Óàm&æ±q`7“§31´Ç˜Eìft;kJ‹Š1è˜eabb)‡ÞfY“Õ$™¢¦m¦ï˜x«	£@<Q´"
+³ÇÉ¢oGãÉdRKtðþ¬ÙK°Ÿõ±0šŸ;‹ÏØ>úïÛ™{ßÿâB ïka2‡G«`‰ï—9ôBþ„â“  ®ôgAz­g-Ãg–êXgišÎêèD·P—@Ö=u ØÀœ™ðg&<Áï+õk%«¤HŒÓž¤Øâì~Qæ q^1Z­@™‰	 ÿëƒ¤SZ{Žx–âj$.ž£DÊ c;Þ¾2k>=Mó~ -
+ñ3žÜ¹ñ£cOã†“Ÿ4î~ô·7w×ï¿gÏž».[ÛÉ|ðúØàuó‹ùÑðª±_þÙ?jŠ¿øVa¤ö#ð¨ 	n6hÂˆ¶(Yº2žG\fõeH‡Qð
+,84XøÃŠ…pi\k¶š1¯·ƒüšd@h’qQ1Rç¢QÏø•µ›R‰hÁ 8nâß V`É›ÏbÑ¸‡}|ÔÏütt9óBëTGO« ýÙãa¸[ámz?8b 5Ï…a³!CšKß`eFD»-„ŒüèLÎP™ÒeÊB‚÷Xg5VC&b
+È+S‰|¡Py8Íe"–rÑ*uÚ®L2“kpütQ¸\åaº(ˆ™Ž¥¨ãI‘¬Q,—G ÂÞÞŒx–+>àJ	ÓÌóAqDJŠ`³Èt…g’ToË°€ÛÂs%².¦˜ÌaIÊ˜Y_ˆ‰8Èâ€L*Îye!?ä.s[­Ìœ27É•	dà²®r—hÃ.QoË
+yÈiW&içòÜ»hkW:iíêk0Ô6#j¸Q¹¢‚ÌVR…â8üã¬b"?–›±MHmG G'¥ý“î/”¾´gùËB!ð„°k9l~æ|õ±h]ÛMÍ»£Î«rƒñÆØÖÀŒPÛºë1ú^Anng¸Rm2–¾´jÓ£Ñ¹¿Ä8$82œ«–·´]Õn››îžR˜¹½®çñbÙ§Ë­Zšé´NË;bÍÍÌüî£pHbÐ@Î{‚¹P>.Ð£ØÝ¹ŒÎé´g¡œ*;‡¡§Î f8§Ø)xn,ûc@À›`	ˆF0.˜æ³Ð6;ic¡-#–	ŒX,Ó¾‚9™<^l$Jµ´•ØJf{”Âêf³s½¥Sgç×{k¦Þ6%ÍÍè<”ËÊ	.5â>2ˆq±Qã!Éÿ+¹Ä€¨«Àç±PëZhµ®ÅM*-ÝÓ´¥8r…a5Û‚y©«iöùË¾lCj4[	k£GØóÀÐì{CEŠ\°"ríCáŠÅÕs¾ªqklh¨¶«ò'îÜ¹è¡›óŠíŽÅýþ¾O/YØ7¿wá"s÷T÷ïýêD59ãÁ»6æ”ƒ²Ð)ëø²à‘¢d´Ì³éàPiÖéõÈ¢{È‡O«ÍèŸSlÄB–\ª}ºB¡ô,=VYè&>’„-< þX€lZâh2:åèQ*töˆNÖ©YtWÌa•¬+K§ÒÍÝÈ"Z¼Ö’)Š ÁÁñûÉÒ¡Õ)ñ„¤¥6s|D®€¹ãñ½Ôä£ÑÑ`€ìY³Š›±_S¡ƒx<¿Í_oé©v™S×õy·tàðØCÛ¶½t ´}:ß¢·Ý¸+ïÅ(ûâÞ¼WOÓ ÓÛ@qËù?S5–SZÓó5ËðXÇ/œO\àˆ–xÑÏÆÃ”Ð¤žÌ|¢PO}þ Å>A»â¤è×‘L{aªa¨;I½ÆzÝ%dËòQâdñ( pM|97 -P°uAÉ'ZâãRÂs$Ç· ªeä®‡7äI|s0Or@oCz¶L@:9×åc†(ƒð!à	¼Ôë1W’	£5,k¾‰2†€ýÜTŠ-€µ­$úÆ††Ìo½ÅÅù2 phsx½¨ér?ƒáUß¿¬ž»\707QH&óë$=’ÖóøJa=ÿ°<ÇOH:9K\Ié<TB"ˆ’í€‹×9n+ÊÄÞJÌFQW•ÁY¬3/Y}˜N€‹tObÒë½§\0ÎrŠ°i}L°ÁJ0bÖdAþUŠ³9Ë™âí99Á%ñzxëéQ2XG¦c‹ƒÍ”›u0ãyÅLëFt¥ct¥qF1RßF-Oó6b}Ô•%S«8§¸^Ì%fÚÖÌvæNÍíÊÁ‰C0T¥“ã<QÜäµ
+e‰ƒîRöÜÕá\6¿öûó‡†Ÿ¸öÉç™­W}» pz]ÅÅÃ\|kÝ’ßÃç
+Œãg˜gøG‘*yÙ
+­6ZÎÌÍ3¤ñYYö(ÒG³q2ŠF¯‘ÕnR°éÉŠê×hÌ6˜á
+ó¡B.‚™Êev§YIð²¬Àæ“qá¬i…D)@|¦Y‚¥§ RAÏ]ìÃSRÂÊÁxÅ\gÄ
+rŠ–ãpþÏT~	ÁÎOÍ/#Î¶$â˜&.–á‡ à·ùÙ¶mCxåØS‚Ý¶¸ræŠcÙúÌg_`nÜ‹+ÇŽìY~]ßïÑ?m…ÿWÀ¨vÝ¹8rá †¼CðÁGœ¡Î*éÄÙdñ&ðWNÆ^Åœ`þ÷#u<u<DL‚«Ë‘8<DÛŠ» Im¤RC^ÃŸÑèq§P7q2“å$ì¹px!‹‘\Z!©²‰>õº;t·é{2¹Ag]ÉÐùƒ)8Â]ˆ:¢+IqŠ¢E…ZÌâVRH4Ò˜‘z:£@š7¸S°¬ÙÎV)Þ*èe_ÖvßÔñ	¬1i	Ø}?ºfoËÂ»Š‹Ë†ÌNgý¢ØÞÊ¡­‹ë‹KKÝÈ¼9zwóæ"¹àê[6 ¯]ÎôÙ„x —Å`×Ï2ÏòYu•,º¼º)0¼)ïeÎ®F»ò¼.Tê
+ÈîwÜYÇÜ.1•“a]gZ¡ƒE%¸aöó˜çÜpÌBN¶ McÆ?ÁLwFÑÃY”É„ õŒBN¦ˆä`·"FácºÞŸÂtV¶ê$]@·J×¥ã?{½¶³9>q$·QjS@5Ü“ä¡K6cLî‚˜=7víÓc×¿†ƒ8ÀÅ¿xœ‹_ü{=y}¥½WCã+Ð7Iö+üÛïº2`MçÂ÷ÉTƒæ£…ð]¨¾ì\ƒšà«Az:Dòž¬’„*¹±µ³k}+ú/¼nÍË
+endstream
+endobj
+18 0 obj
+<<
+/Type /XObject
+/FormType 1
+/Resources 19 0 R
+/Subtype /Form
+/Filter /FlateDecode
+/BBox [ 0 0 58.14413 10.2583 ]
+/Length 281
+>>
+stream
+x…Q»NÄ0ìóCgñyílì”<®¡;É¢@9"âN
+¾Ÿµ"‘äbw,ÏÎìxÄ#¬Ž†š†<ÈÇÑãý¸`w;ú	+:òÒ`ê¸]8±P¬¯„4”‘Îëˆ	kÃÞÄÈÑ¡ÝŽÎòeæ˜UäÔ„ÚµÁ°c‘Î4šª?ã&¡¶ÆZËH=ØØHÎŠœQfk|ã<Ò»”²ã4àêtÑUõ¥ARžßtVT§#>?ævÐðªžQ„ÆÒ=ö©ìö¿ÉÕKÙfE®¦ÜnIèÙ™ºÒH¯‹Jõ‡
+æ(Ö¹¿U¼uFDâªRm÷ßßÉbòÍP²™5ukes•,~îã‚å>'P•ßN‹sí
+endstream
+endobj
+19 0 obj
+<<
+/ColorSpace <<
+/Cs1 20 0 R
+>>
+/Font <<
+/TT3 22 0 R
+/TT1 26 0 R
+>>
+/ProcSet [ /PDF /Text ]
+>>
+endobj
+20 0 obj
+[ /ICCBased 21 0 R ]
+endobj
+21 0 obj
+<<
+/Alternate /DeviceRGB
+/Filter /FlateDecode
+/Length 2612
+>>
+stream
+x–wTSÙ‡Ï½7½Ð" %ôz	 Ò;HQ‰I€P†„&vDF)VdTÀG‡"cEƒ‚b×	òPÆÁQDEåÝŒk	ï­5óÞšýÇYßÙç·×Ùgï}×º Pü‚ÂtX€4¡XîëÁ\ËÄ÷XÀáffGøDÔü½=™™¨HÆ³öî.€d»Û,¿P&sÖÿ‘"7C$ 
+EÕ6<~&å”S³Å2ÿÊô•)2†12¡	¢¬"ãÄ¯lö§æ+»É˜—&ä¡YÎ¼4žŒ»PÞš%á£Œ¡\˜%àg£|e½TIš å÷(ÓÓøœL 0™_Ìç&¡l‰2Eî‰ò ”Ä9¼r‹ù9hž x¦gäŠ‰Ib¦×˜iåèÈfúñ³Sùb1+”ÃMáˆxLÏô´Ž0€¯o–E%Ym™h‘í­ííYÖæhù¿Ùß~Sý=ÈzûUñ&ìÏžAŒžYßlì¬/½ ö$Z›³¾•U ´m@åá¬Oï  ò ´Þœó†l^’Äâ'‹ììlsŸk.+è7ûŸ‚oÊ¿†9÷™ËîûV;¦?#I3eEå¦§¦KDÌÌ—Ïdý÷ÿãÀ9iÍÉÃ,œŸÀñ…èUQè”	„‰h»…<X.d
+„Õá6'~khu_ }…9P¸IÈo= C#$n?z}ë[1
+È¾¼h­‘¯s2zþçú\ŠnáLA"Sæödr%¢,£ß„lÁt 
+4.0,`€3pÞ  „€H–.Hi@²A>Ø 
+A1Øvƒjp ÔzÐN‚6p\WÀp€G@
+†ÁK0Þi‚ð¢Aª¤™BÖZyCAP8ÅC‰’@ùÐ&¨*ƒª¡CP=ô#tº]ƒú Ð 4ý}„˜ÓaØ ¶€Ù°;GÂËàDxœÀÛáJ¸>·Âáð ,…_Â“@ÈÑFXñDBX$!k‘"¤©Eš¤¹H‘qä‡¡a˜Æã‡YŒábVaÖbJ0Õ˜c˜VLæ6f3ù‚¥bÕ±¦X'¬?v	6›-ÄV``[°—±Øaì;ÇÀâp~¸\2n5®·×Œ»€ëÃá&ñx¼*Þï‚Ásðb|!¾
+ßÆ¿'	Zk‚!– $l$Tçý„Â4Q¨Ot"†yÄ\b)±ŽØA¼I&N“I†$R$)™´TIj"]&=&½!“É:dGrY@^O®$Ÿ _%’?P”(&OJEBÙN9J¹@y@yC¥R¨nÔXª˜ºZO½D}J}/G“3—ó—ãÉ­“«‘k•ë—{%O”×—w—_.Ÿ'_!Jþ¦ü¸QÁ@ÁS£°V¡Fá´Â=…IEš¢•bˆbšb‰bƒâ5ÅQ%¼’’·O©@é°Ò%¥!BÓ¥yÒ¸´M´:ÚeÚ0G7¤ûÓ“éÅôè½ô	e%e[å(ååå³ÊRÂ0`ø3R¥Œ“Œ»Œó4æ¹ÏãÏÛ6¯i^ÿ¼)•ù*n*|•"•f••ªLUoÕÕªmªOÔ0j&jajÙjûÕ.«Ï§ÏwžÏ_4ÿäü‡ê°º‰z¸újõÃê=ê“š¾U—4Æ5šnšÉšåšç4Ç´hZµZåZçµ^0•™îÌTf%³‹9¡­®í§-Ñ>¤Ý«=­c¨³Xg£N³Î]’.[7A·\·SwBOK/X/_¯Qï¡>QŸ­Ÿ¤¿G¿[ÊÀÐ Ú`‹A›Á¨¡Š¡¿aža£ác#ª‘«Ñ*£Z£;Æ8c¶qŠñ>ã[&°‰I’IÉMSØÔÞT`ºÏ´Ïkæh&4«5»Ç¢°ÜYY¬FÖ 9Ã<È|£y›ù+=‹X‹Ý_,í,S-ë,Y)YXm´ê°úÃÚÄšk]c}Ç†jãc³Î¦Ýæµ­©-ßv¿í};š]°Ý»N»Ïöö"û&û1=‡x‡½÷Øtv(»„}Õëèá¸ÎñŒã'{'±ÓI§ßYÎ)ÎÎ£ðÔ-rÑqá¸r‘.d.Œ_xp¡ÔUÛ•ãZëúÌM×çvÄmÄÝØ=Ùý¸û+K‘G‹Ç”§“çÏ^ˆ—¯W‘W¯·’÷bïjï§>:>‰>>¾v¾«}/øaýývúÝó×ðçú×ûO8¬	è
+¤FV>2	uÃÁÁ»‚/Ò_$\ÔBüCv…<	5]ús.,4¬&ìy¸Ux~xw-bEDCÄ»HÈÒÈG‹KwFÉGÅEÕGME{E—EK—X,Y³äFŒZŒ ¦={$vr©÷ÒÝK‡ãìâ
+ãî.3\–³ìÚrµå©ËÏ®_ÁYq*ßÿ‰Â©åL®ô_¹wå×“»‡û’çÆ+çñ]øeü‘—„²„ÑD—Ä]‰cI®IIãOAµàu²_òä©””£)3©Ñ©Íi„´ø´ÓB%aŠ°+]3='½/Ã4£0CºÊiÕîU¢@Ñ‘L(sYf»˜ŽþLõHŒ$›%ƒY³j²ÞgGeŸÊQÌæôäšänËÉóÉû~5f5wug¾vþ†üÁ5îk­…Ö®\Û¹Nw]Áºáõ¾ëm mHÙðËFËeßnŠÞÔQ Q°¾`h³ïæÆB¹BQá½-Î[lÅllíÝf³­jÛ—"^ÑõbËâŠâO%Ü’ëßY}WùÝÌö„í½¥ö¥ûwàvwÜÝéºóX™bY^ÙÐ®à]­åÌò¢ò·»Wì¾Va[q`id´2¨²½J¯jGÕ§ê¤êšæ½ê{·íÚÇÛ×¿ßmÓÅ>¼È÷Pk­AmÅaÜá¬ÃÏë¢êº¿g_DíHñ‘ÏG…G¥ÇÂuÕ;Ô×7¨7”6Â’Æ±ãqÇoýàõC{«éP3£¹ø8!9ñâÇøïž<ÙyŠ}ªé'ýŸö¶ÐZŠZ¡ÖÜÖ‰¶¤6i{L{ßé€ÓÎ-?›ÿ|ôŒö™š³ÊgKÏ‘Îœ›9Ÿw~òBÆ…ñ‹‰‡:Wt>º´äÒ®°®ÞË—¯^ñ¹r©Û½ûüU—«g®9];}}½í†ýÖ»ž–_ì~iéµïm½ép³ý–ã­Ž¾}çú]û/Þöº}åŽÿ‹úî.¾{ÿ^Ü=é}ÞýÑ©^?Ìz8ýhýcìã¢'
+O*žª?­ýÕø×f©½ôì ×`Ï³ˆg†¸C/ÿ•ù¯OÃÏ©Ï+F´FêG­GÏŒùŒÝz±ôÅðËŒ—Óã…¿)þ¶÷•Ñ«Ÿ~wû½gbÉÄðkÑë™?JÞ¨¾9úÖömçdèäÓwiï¦§ŠÞ«¾?öý¡ûcôÇ‘éìOøO•Ÿ?w|	üòx&mfæß÷„óû
+endstream
+endobj
+22 0 obj
+<<
+/Type /Font
+/FontDescriptor 23 0 R
+/LastChar 33
+/ToUnicode 25 0 R
+/Subtype /TrueType
+/Widths [ 1000 ]
+/FirstChar 33
+/BaseFont /AAAAAD+LucidaGrande
+>>
+endobj
+23 0 obj
+<<
+/FontFile2 24 0 R
+/Descent -211
+/CapHeight 723
+/FontName /AAAAAD+LucidaGrande
+/Type /FontDescriptor
+/ItalicAngle 0
+/StemV 103
+/FontBBox [ -1067 -737 1641 1162 ]
+/XHeight 530
+/Flags 4
+/MaxWidth 1640
+/StemH 77
+/Ascent 967
+/AvgWidth -490
+>>
+endobj
+24 0 obj
+<<
+/Filter /FlateDecode
+/Length1 9208
+/Length 4966
+>>
+stream
+x½ZxTE–>U·óîN:IÈm.áuá%&ØBçÑ(D° Ý ØÈ#’€òD4|€ŽÌŽŽâêÎÎìŒrÓ‰cG…duñ“]]‘õ9º€:>¾YÙaf™otèýëÞÛÉdü˜Owo÷©¿êœ:§N:U}ïMZ7nj$µ“D¾¥¡æU¤_Ê«€ò•ëBÍFÛõ°dåæVÙhg§¥þrUóëŒvA?‘mÚk·˜ú£ÐùšCaCNBFF›MŽnZ×z«Ñv}	L_»a¥)U„vêºÐ­æøôÚòúÐºF£¿ò$p\ó†–V³-úMoÞØhög~"ëAbàr’17q1²ÓdÚF”rÊ6Íä`–º«æ•7ä¸ÿÀœ˜®ž¶—^xâÔ$ÿÙÍrÚ\óÑÌÐí	ì¦½pÎ‡9<»ùl­Í•”©¸xŒnVct#èzÐbµ:Ì9dqjãuÄølî†žÊgqw”©¿}ž_æåh”Ò!Èì Îv±ÎhI©'Æîî¶VQu6ë$;ˆ³;Xl©ìNïbQ®¶?ÏÚ`ö$ÛîYÅNž*6üÍ·PlÛ^èÌÙVº­b›´m{ñÇÁÚ|ŠuÍ(Ön@qÓúBçëÛnâ7­oÛXÒº©À1üÆ5(V­FÑØTà¼¯ñ@ã±F©±©ãæ’â–Â­µÅ®- Þ+-’æadû!iù@œ<RU4+»ª7Þ/UF³ÍJw†µÊW%M$&M–¦`UTþ%ÿJ~=ÌÕÿ ûpsåïwO™Y%0ªŒVP)(Ð+ïE§U™•	“ÌŠK1+ÃŠÍJv®^9ÍE…·ó[…{Õ*o%ˆ#´×£v=jYü*r‚nIhÕ£UOœÏä*¤R^	ÌNåSD°ùd+€#ÁŸÄ§DG–Ê1@^aU/;Ë>ŽJjfµÌ¾$Æ~Ëþ[h±Ó&~aâ™ø9ûL„}
+´ ?¢ü_ÙÇÝYp½zŒ6£¼KˆØƒlŸnð÷±û)Š{iÀû€bÀ{Ùý˜r_šŒšQ¶»6ºÏ¢ÆØâè^WG÷˜ÑÝ&©H°ªh^QUuÍÊt§ì,WG‹ç²o¾?úþÈ=Ÿ–”TýèaI}äa‹úðþLõØÛ»/UÝK? ýp?WÚ/©ö³ÇöÜß·_zAºRš+&'ÍvpU¤Dm·=·ªô°„M@§D)]"MGÔäê<iMy@>Eš&'¤©&VHèYÑ‡&v!²Gq~&z(ùóQ´/]Á?Œ§§À‡QäBŒŸŠîÊ„üdwŸSåït+e"¿Þ‰:°hè<
+—ªmüe~DÄ“¿Èûuüg÷ß_à›ù-b*üs*üfc*|£˜Š^zx0a4ÍÌÒ­ßV¤W–GG×+Ku½ê¾LWeŸ‡²Ï¥1 N|"ƒ8ÜS£¹]o|·-·
+Ù¦ˆl;ÄGqY,7wq9jQÂžŒ3d$J±¹J)ûŠ½®/ä)öC;Éž‰ŽqÉ1v2:ÒUU]Âþ“} gÍû&þÊÄ÷L|—½£x‡½­÷{›½‰ìÒúÐdì-ö¦Îü¹º:‹Ç<zEÉŽ›²7tF<Å!Ð‹ü~]ä·ÚÇž 'A= )~Šý$šïÀ2°{Ø}ÀÝ&F€"­¯‰Þ…c‚-‰¶K€†è])€EÑ]F;ø¢B¶ Ú!à*±P1VÝ%`J´O0GÌlO„úÚ¢~-:Åû=™‰ù;õÍŒ.Çð*Ï'HyÑštÐ–SO==¾ž`OsO{OÏ±žS=gz2z†K?ÿÌ¢ÞIS#»SÕ= ¨<{ïä©U÷Þƒ!¡^pÏH¥êžÝ\ÝÝ‘®î¼Ý¢Þ.æïïnŸ7_ØïnŸ]kàô*ÇMÒÇµ¶PªÚwpµm‡nÕc½Í;·ê64vÀ’0-wÂt'f¸Œ»:RÕ;îÌTï6w´wð¾V)-–([òIQ.®eT
+—V/‘®’æSŽä”†K#È*åHv)h•lR6p,p<Ù$ä
+p$ä2p,¹%h$È	ÊYÉÍŸâOóƒdåó¿çO åñÀ^àódãÝ?Ô {¡ÓÒ„.èqÐ£ ÛùNÊæ;xÊíü6Qêþnâ[ù6ì;Ïåy°kãÙ<È8çYÙ9çøíÇIžKƒ¸è‹³ÞNú@'A)8¹m4Ô’¨”Ã¾)†®>åÃ¦X?òAv”
+bäF_7;Ä³>Œ×Å¢¬ø4;È4àQà¿‘½ù`?ä/Bç%P¿Ðuž­cëÙè…Ø
+¶¸œÝÀ‚z{UtXiiu[E³Am ‰mt¬µ@k°Z[`©Ô,,‚VB å r6‘rØ6å86ž²Ù¦¢,bÅàä±|”ÌN!†2…¥¢äLB‰-,JÏO‘*çâ9ÎKE3ŽKyÓ9ÓÖ©ŽŒ)ŽÔÉ©ÂA“cÆf›3AÍ.WsF)Ù£•œ‘¥ÙriNŽ=×š‘™eMMK·J–+"m%É“_¢”_š*/-Í™Ó–#É+•®–ú¤¸dq²¶¢´›Ã>Ì–g)°Ýïdåî	îqî1îÑîQnÙ=Òít¹î<wŽ;Ãê–ÜäöMcZ^=Õ7Ôhù¸¸F›¦ÖÇ$y‘6U­×2|Ëü]ŒÝ Wã1Fš¥3ÆyµK—ùc¬Xˆ;œ½bÞZ}°ãž@§ujÊb¿ ÏB¿&wÆìÔàïâ¬&h—ÖûP§š€:B×£[ûˆ€6UTî zmæBÍ©Ô¨ƒ¯ÁhiÕá¼¬kÜ¯6ÁÒÊ½ÁºólU%4à°W;çÅWK°-¸ÌfŒo÷ÆøV˜á;†6“Ô‹I¼1é*t•|¢kkKÊ†¨´´‚Éôr°T¼u WÂ TE<t¸ ÐÝn1t¡˜’–Ü^0ÈÓ6m
+­•ÕúUÕŠ4I’P0-
+`1¶]ö®©‹±ÛØa@›íÜnÀNî0àN:¸Ë€]tp· sf¸+¹Lçr·—0Ë€Ùx¨6 Æ€Zêð0Ç€+ n˜[KW†È~ß¢šz-}È·L+QÐxhX•JU©OF¯PY¢4dŒÒ2‹ÄÅß×ËÏõs›âzèÜ»‚÷].ñì%Èò]ŒÝ#„5~Y|oüKê£&*ˆWÇÿbH³;ã;è$§£ÔCOÑÃtõ#t˜zéçô1ê/£öý€V@ûIú1u ÿ‰§i#øçÈ_ÚfãðÎÒYÚÏªipðõ ¬<8˜ùWÛŸÆK†ˆ¢í´oâ¿¦MøüA.è¹õ <ÿa§i{Va>¦û¸/þ›”£T(ÝŠGž–"\‘Ÿ¶PXz$þ;äINš?ªã¿ÏÒ®oë·c'®^ÚÃ2iâ6…®†¯5	Á@DÏb+1—øìÇjtã³ãî½°gjh%üN'#[y”"Þ5àŠºU¯ñ63öCÚŒÜ4s9ñRäÍ•ñÆø–øã‡bõbfEZ?£½l?<XA×Ñ5üU<Ø‰Ö´¯¡yl³Ñ£°}‰>J²0w•d0DŽ‹+áŸÅŒ¢¹·à¥qÅ/KÔØ>ü0Ÿ¥Wè%Šéþ<Bû(BíˆC+ò{)ùàûL¼–0ú}¢ç°ðü|ŸåÔ€ÜÃ…œ…ùœHØ˜ò–¾÷Íw7áŸØûG¤Eã:—¨½†•4vC'¢±	ñX‰•=«ï±~G°j#×²k’Ò—õµýgÑTáE|f|bÿït-màÝ¸a¹zç‡JÖ~n"“‹è›•”¬|—¼ßŽ=t„`°ƒ®§ÆœAÁñ$¢™r·ŽbÕ~‰ñ¶á³}ˆN½Èï#ˆÓVZHÕ´ëxû£	{8Œˆg2ÖçœbC]!Ø=†UÙ ­’ÌUª2D|†¸RNÌtbd~2w]ÜM´à¬‰ÞeyÈè]äÄSô,Î’Yl\Ûí¤õ4ÁüÇ³hî•îËfVU^:ã’éÓ¦N™\1ib¹:aü¸±cÊF+£\réÈÃ%ÅEÃ
+ùy¹öœl›5+3#=-5Å"á~¾œiEµ~ï­¸6ˆßÂ:Å.kÖgæWh”çt)¹ò´ŠÀD³—–¢j”_¯àž<•-UÜe&•Ùï‚ò|§ìÕ,eø*óBamÜ"¿K±¿íLÊ0«•Ôú].§ÆËð¾óBrX³ûÀ‡@çÌÕÈç‹T	&Uº(ùµ‘‰&nE‡p²;ª›XÄÞe-®­Ó¨ ‹¬iäÝÎTÂ´q¸5.³£¦[£
+ü^cùsÌÇ”!ÔNUoxâ¯FDÃÁó1=cDÔ%GäÈ"î4§Ë¥;;‘…þ®¬ÌZ¥¶1³ÀM3Ô•™N–``Yš»˜uÓ+Üê‰;îtÂ—'Üõ
+Z£yvQQê7HòÏKð¼çBAÍèDè¦×˜>¦–Z«¥NÈ«5OH£ÝrWydîøWUkX	‡®ókRNu‘TæmjÐ†×û–‚'@Á&Y,w^ˆÅ“½MrmÑ7ˆR©ƒê@~¸©1(Ò„•:È2jý»\ýN<’øwyµ\U³AÝ¶õ×N)â-Z-‹f$²KÖàQä©KôAM,—#^£Á˜wMX±Šä²éÙ87¬/ŽgwHÖÚW¬AÌðíIä¿+b×¬_¹°:XhŠÝ!,(\#¦²š€ÙÝ¨Ou>5ä«¸í$‘ý´ÚKýÞ&Å‹xš" Ð—Êëº\Z±*#¯p1†÷"2øãfnì	§ÊàO­æiÐô5ÀˆžP]Àd™ ±`4O°.“2@K+Û•2I‘#ÂhZ™V Ú]ÿYÿÄòúE~oÈNôäµþËO9O£Ž½›¡O¤â´’,VêYÐ$â#Š`ƒ±5såÑÕì¯[}­Èùtç(s‚‘ÈEž	FB±xû
+E¶+‘.«5ÒìÊúÎgà?·Û©ÍÙÐìÁ&6‹,òmîàó.Ë3Gn
+ƒïlÅUétåÂ´Ñ'ÇÐbsŸ!ã‘÷bŸEì_`ÆVœHNyŽ8^b8œš½RlSx²Ä}°CxÃzýÇ\î;E
+”yW/6ätaH=aÄ¹·ÐäÂˆË%öÐî˜‡V ¡µ/ôm™V8£ä©P±vA!éOHK„¤=!Iª¬U‘xÌÖsâ¯å4Îód>Gr•<¹Jæðß¹a­¿süc¥–ŽˆéË_ë—œ\tA;%QËTñ“àÖ†©º¢ˆ	NÉˆ]‘)š]ÕRjýýNw@¶çâ€dÉd0-Š4µSŽ2qˆR]cnŠmE8TFúÃ*!L*ÊÞHÐÌ¾ç‡®¢w¸)¹ŒY`ãŠI"vûÖiÄ#7OS}Ud»ñ§¥”Í›
+k£Gl^@Ë?vZözÉ9ký2Ž!lÛ…zEöÊMbÕ59X§Ÿ§'Ø±ø©`8ÿüH4tqšù,GØÌ=a†¡¾ÁŸ¨-òßæÜ˜ˆ¿Š•×Ç(¿¤âLŒÅ;bT7¢g“nXqC¹,{W×a@4–”ƒ1Á…Ú5åÈM‘ú~% ~Iæ†#²Hþ0¦¥#‘@òu±ç%^Õ¸4OÀ™¬63açZa*è	ÀÂÓPgUüüåõ8©Æøü8lÛëèubcºýØUýbÆb"¤§ðø¶ÕE¦ÏKás`äË+ÈÕv˜D"Âæb¿‚4DœÌÃlãÏ`†ÇdÄH¨`âÞk÷A è÷^Å¥ˆÈê0Ôuˆ{â”Âß¿=ÂË“~Cóx»\pð{Špèb"¼â¢"¼2éé€‡áóJáÆ¡#¬ñ1ßãCê1Bê"¤«„ôÆoiSÒQxµî5é!]ó=…ô¦‹	éÚ‹
+éº¤§Bº>¯!Ý0tHÿ/’¶y@„oþöoLú'[àíF=Â­ßS„7]L„7_T„oIz: Â·Âç[D„·üÿExëÆ6™þ¦_xÃ¯?‚YÁ´¢&þ“ÁàÉôSpð„„7øàÏ$iTðl*· Š×Þ|M/¦LvåºrËP0<~ã‘Ú¿iO¡¯Éci‡&´(ŽÑÒýRzÂøÏ¹"F.l‘åõ”€h§£Ì º€vðK>¨N¡_Q	ýÄ¯¯vâg¢/Jh<¨
+4 ­mÝú;ÐÏ@½ £ ÛõxƒÂ0”Tñ\²P«úåãý†ÀBøÊróª&OÉÍà’ëñ™>c6ÃsåeTšcÆ´©Ž‚–ê°ˆyR'³Ÿ;Ãìò•³úú½§ŸíŽ¼}§g…¤‹¾A?ztA[ î²ûî¼ÿ+__ôóû®X{XÄW¼ÏíC]3ž…ÿdYZÙ¸®q}«Þ‰áŸŒuI…¿T-®:õªM+W‡CWl­ë¯$+GøO¢áqó’uÿ³hÿ/¦-Æ2
+endstream
+endobj
+25 0 obj
+<<
+/Filter /FlateDecode
+/Length 222
+>>
+stream
+x]½nÄ „{žbËKqÂ¾!Eä"?Š“À°XHñ‚Ö¸ðÛˆs‘RlÁÌ|0¬¼O…ò£1ƒä×¸±E˜p$ú¸`óqjš]L²Àã¾f\ò” ò½ kæN.NøPµWvÈf8}^Ç¦Œ[J_¸ eè„ÖàÐ—ëžMz1‚lèypÅy?ê/ñ±'„Ò¨ýO%®ÉXdC3
+ÕuZÝnZ ¹ÖLþH^z­êxï]Ëÿ:­_¼W²siÓöÐŠÖð¾ªS}°Í7®fpæ
+endstream
+endobj
+26 0 obj
+<<
+/Type /Font
+/FontDescriptor 27 0 R
+/LastChar 118
+/Encoding /MacRomanEncoding
+/Subtype /TrueType
+/Widths [ 313 0 0 0 0 0 0 0 0 0 0 0 0 363 0 0 546 0 0 0 0 0 0 0 546 0 0 0 0 0 0 0 0 600 0 0 678 561 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 525 0 0 553 0 318 0 0 229 0 0 229 0 558 0 0 0 0 0 334 558 498 ]
+/FirstChar 32
+/BaseFont /AAAAAB+Tahoma
+>>
+endobj
+27 0 obj
+<<
+/FontFile2 28 0 R
+/Descent -207
+/CapHeight 727
+/FontName /AAAAAB+Tahoma
+/Type /FontDescriptor
+/ItalicAngle 0
+/StemV 0
+/FontBBox [ -600 -216 1515 1034 ]
+/XHeight 545
+/Flags 32
+/MaxWidth 1550
+/Ascent 1000
+/AvgWidth 444
+>>
+endobj
+28 0 obj
+<<
+/Filter /FlateDecode
+/Length1 9216
+/Length 6048
+>>
+stream
+xÅZ{|TÅ½Ÿ9¯ì{Ï&»Ùì.ÉÙe“r6Én{òØð t%		D$à£(±µ‚-ÖV¬å£ÜúhµO6€ÁFXå¶*¸(­­mj­n£~,ò¡H’û›9› ê}|úÏÍœùÍû÷øÎofÎIÏÍ›;	õ")«×·v#D;$GWoéñjù4B¬nM÷ÚõZÞ õüÐÚ›n[£åm¤?ÒÙÑÚ®åÑEHCP åq)¤¹ë{nÕòÖãÖÜÔµ:U/þ‘Ô¯o½55?"yï†ÖõZ{ÿ0ÉwwmêIå÷BZÓ}sGª=n~úµºËžhš²‘À )h9Hò ó2-!õ<ó[
+Úž[e­øyt´øÉç§âå´[û¢t¬ÖäÕÕBV#húéðX3B¦5_”^¸ÝäEd¤Ëƒ­¿U¦ã; B„§q7DEñf´ŠÆ-Då¸k `FHÄ]	§'4ˆ7°³}»+Ýx#ô,†çˆÝƒxâŸ!
+È
+Ï(ÄU·AäÆ“¸!1%;tˆÕ‰ôJ\()M¹ù0øÕ™’õ|-ú"³¯p¹Éì+š&D‘öhÐHAwŠ½nÂ<žphD[Âî %mó.› Ö&!Zµ6aÉ§Äš„ÞL‰Ö	¢#Q¢µéHÒªŽD¶˜ìH¸]™©5Q¿4Õg^4E¸4	[2(»­F3árU¢ H[Ô'V¬ÔˆÈœPqe&®)ëA‹õ ínxöB3âv°K;PÇá9L(Üžèn§×&2ìtÚDffŠ mžª6¢ÚW€0XhÉ¼„3‹sF p1(Æ ôÁ‡íÒ‡'‹%ïŽ€#0~$ÁfI•<ˆCj†´v)Pi‚<Æ!\‚,PZ
+©ÒY¸$!JÊó¸ T®ë_e”·§æ†NœŽJovK½oâ7!‘NãîÓøÕßJ¯þ&Rþ*6þºæ×Ìàxòàõ¶PýI¤’“˜‰	oBI,It'zûjâxb8aH&>MÖJÍHªÁÖÒ
+¦~ùªåLù‘B©ë~ìÈ³G˜ð!‡ø%:ì”^8œ)~Á!=h™tðÐté¹CAiâ¡²ˆ4ˆ7)³£A©âÜè\i^Ô'UG³¥ªè2©¢1Z”‚%íRIY©TVÚ(•–åHÇK‡K?-eÇ?ØŸ· 48><°_ôCú±bÙ¯·†ö»HÇ7àáTýÃ¤A¼Áñ}w:€¢AÄpoÐ§‡º€•µÐ­{Mïš}kÔ5Ü³G:¨”…íÐ«ëÁm2]»q÷ýxÛ®Çv1½û0j[Ò–lc•ÖîVF¼Ö{íîkÙAÜ£<gJöÒ Äv›TdÏ“d{D*´gH.ø¤€y£€$l]”õVK’=GòAêµWH¹—InÏ|Éã®Ü0ŽúeØ+¥t»[²Aì¶cÅ^YB¶bøà(îÂÛð³ø~‚Ç±ÁŠ°Pu¡mèYt½>AãÈ`Ð‡%+ce™7˜7ØqfœåLæÏEX&‚Qd	¡·š^‡ê«ÔiCU¿>(×©íËª¾}ß}ÙêCuËšÔÞìæA´iR±ŠïoVuu)É6õÀß¦•©B¬³Uü5›HÆB2ª•ÐVVí±NÕî¯‘7‘®“ÆÐÂ¦T7mJ5ÑªÐæÉ¶—djhJÜ##èEK !µ!.ŸjSOÏ×DGÝD’ÁÏÆ:á‚ÐÖdðÞBŽ`ç?åOp[¹8{)ÿ`ü/c·Žµ5³?DÓ ÉCètE¿töCè%JoA	”D¯M–â.ô=ôz½æš£GÑO‘
+Ù=@Ý×à­h7"¥O §Ñ/Ð zi»ÓD¯Kÿg§Š_fìXãà#dbNàMø~yª‚ßÑËºî€=>¿!àqf!eV2¯3÷2]LX‚¹¤K²'Ù£ÅðK¢·Ðá¯ü.üOüOÔƒþz{Ÿ9Š~†~Œ¾v @ê'!×…¶£ï ¢}_î-ôñ6î³+JÑÏÑ=è:ôÐô+ÐãÔ õ{`,„î@äFß’êñúQŠúO¸ë™ ­ï1ÇØ*fˆQÙ Ã±CøÀÛ–C-ðkþƒÖ :ÐÇSè'hJHØÈJ û$l„ß#è<úó´ßŒ6³{ÙYP7„æ¢6ü¬ƒÞt?ŠÞE+á×ã]ü2hzrC¨Ð6Ä½–•öw´
+-…ø~Ž;È¿‰îDë!¾‚Ö+sçÌŽ”‡Ce¥%ÁYÅ™3ŠäÂéÓòórýS}^)'{ŠÇíÊrf:ìé6Ñj1›Œ½.Mà9–Á¨«YÕMý®4Ùãóùšg¤òî+ó*›'~æSQú<W6êŸò¥|ö—ò9“ù«UdWkýÕ5dà~Tû¾Š2TlW™g\3¥8‰µ¯óÇnP]Õí--Ð£Æ/zÕÚO)V(ÃýFCµ¿ºÃ0£õŒ@‚¶Ýý¸v¦S›ÝÏ yF‘š.«L^ŒÄuª²³ˆ5—j`WÚuy‚nZ#Í(…U¡ZM£ózoP•Víôö%ûvŠ¨­E6µûÛ[¯kRÙVPj?bóbà³!!±¥Ó«r0/}x ÄëôöAž4k§¿z}m9ë«›¶û’5Ò˜j“ÕùÐsþíïyØ¾XÖ^’íëÛîU÷-mº¼ÖGÚ477gÍ(òöÅü0QÍŒ¢Øº*ÐtV`FQžPM{Ë:ÂËºVÂgl·ogåuå6u‚aZÿ·V}}±v¬½µL£W«J#MPãJ¢oTWÓœ*J5€ŽÖ´Ô4ƒ®	c°õUCmÌßZ$8,iI•@Al¢ÒKø\¨*-ªwµWEËšüÐ¹œ<:ÊQßêr‚cÏ(ª[r©—Êç‰~oßçHÅ-þ‘¿Ž/•´¦J„<ñsD*kýµ-}}µ~om_K_ëàxo›ß+úûúëêúºc-0ëØ˜¡üùµvW³*¶tâÙ {‚€ÚeMQÏrhÙ%Y`„ÉfÏåÁßÂT¶@MpRQÑò¦f(²‰Ð@k) ·lœRÑQ&"tŠôù:w*¨ì®ö.mÒò^ÔæI % ƒ=ZHMr¢Æ±œÔôNÔLvoñƒqöÓ•CÕåOþYÅÌŒXçlgþÕZ½šQÝÄzx K(ƒ+½BuÊ@È}`–ã~U”U¾)é©höŠ6ð Äzþº¥+›¼±¾Ih%)I	 êþÖÎ¾Ô# ÿúRrÒNKz'h¼·m€þZw÷ãëÕÚs>¯ÏæO÷F„U¦º±)Å•b*ÀáTõûñŽ¥ý
+ÞÑ°²éœQ¼;›fª[ªš›gè@qL/\v?D+¹ëQÄEÜëãçøõhwÄ4›»	Íav¡l|
+.§Ð.nÚÁü9 íe/ÂõÁ ÚÖ¹AÈ{Ñ5©È|%À…
+û¥rîKy¸kÓ¥}¥æÿV ]ÏõÐØ@;éÞMÀEêR° +9»Ñ !	îÿ¿Ã/2W1'Ù\®’·ñ?–	GÒzÒ.êë¯‚‹4L#B³ØŸ‘8öÎ1ú˜Uì³ùlyðÀÐêB/¾ )‚èi%3‹¹Ÿyzg+z\Ål#z"wŒ“-Ìä’@Ffc_™¹ôu¦”™u .žãáŒü'Èˆüè%ÅQŠçcx‘ñv?ÛQæ[äˆù8ýàø§J–ÅfEx8éß!Ö`õ‰p`Ðàø©ýf33ˆO÷›L”xk¿ÑH‰a(HÕ0´¡ÄE¥Èh
+y|û„¤À"é,ˆ¤§Iº	&ÒT0‘žÂàø»0%’f[X¤Žåñ‘’AÑ‘èˆ,ÇgÇ±Èø§261½$˜ŽCprÈŸ–ŸïŸ*¤	‚ÃžéÌÌ,	†8ãGÿ8÷>‰ã(;++'ç†Æ†¥œÌoö+nd>ë»ß‰wàñæ±;/\ôî#?x·nq}ýÕ‹?üîÞ“W5kü¢ñ?qvþpMÎF³±tÐa2ß¦Áñ³û	aœ èñ¬²šÔÚŠuÅ–bW0¨è‹âª
+6ã•|£n•meú*g£«1»azCI<ÜnèpÞäkÉ_]´º¸=tCdkú–¢MÅÒ4‡©LŸ.ä°ÏÍd<ƒ9ä5«ÜQ [}¥&±—kêfæ q’Z‚” Z-…ž¥æbL±QMûär9Ë·/7™Ëä’;k¦ÅÎ¥fÉ#0sr©Y jX1[äRåNª¿¤$ Ú'Ùx$2b‹DlP@m’îŒ€M¨Åp)1ƒfg(”A3ZL‚§;••†Âe4)	Â¡NHsdB‚Xùž[Öïœ?_ÚVzÍ¼)ÖNÝ8¿¡éñoÜùðØ‡]•hå]ßØ°nìå×>ß¼á›÷Œý'·¥ýž[×,Z3ÝVa«¾otãu7•gå„ÿmívuÏØ©ªyO^wÛk‚òðÍ?~ó©öWÂÂÜ_Ü{dl1ãçâÞâOÀú3 á~x¿CP|V‘ˆž0[gà¥‚ G˜åtHÇrz”†ýÓsD3z½ÉhKäSÇÄSÇP4MD#I1	O–=Ê"Ø<TÝô¿ÃœeX½AØž†Óàm&æ±q`7“§31´Ç˜Eìft;kJ‹Š1è˜eabb)‡ÞfY“Õ$™¢¦m¦ï˜x«	£@<Q´"
+³ÇÉ¢oGãÉdRKtðþ¬ÙK°Ÿõ±0šŸ;‹ÏØ>úïÛ™{ßÿâB ïka2‡G«`‰ï—9ôBþ„â“  ®ôgAz­g-Ãg–êXgišÎêèD·P—@Ö=u ØÀœ™ðg&<Áï+õk%«¤HŒÓž¤Øâì~Qæ q^1Z­@™‰	 ÿëƒ¤SZ{Žx–âj$.ž£DÊ c;Þ¾2k>=Mó~ -
+ñ3žÜ¹ñ£cOã†“Ÿ4î~ô·7w×ï¿gÏž».[ÛÉ|ðúØàuó‹ùÑðª±_þÙ?jŠ¿øVa¤ö#ð¨ 	n6hÂˆ¶(Yº2žG\fõeH‡Qð
+,84XøÃŠ…pi\k¶š1¯·ƒüšd@h’qQ1Rç¢QÏø•µ›R‰hÁ 8nâß V`É›ÏbÑ¸‡}|ÔÏütt9óBëTGO« ýÙãa¸[ámz?8b 5Ï…a³!CšKß`eFD»-„ŒüèLÎP™ÒeÊB‚÷Xg5VC&b
+È+S‰|¡Py8Íe"–rÑ*uÚ®L2“kpütQ¸\åaº(ˆ™Ž¥¨ãI‘¬Q,—G ÂÞÞŒx–+>àJ	ÓÌóAqDJŠ`³Èt…g’ToË°€ÛÂs%².¦˜ÌaIÊ˜Y_ˆ‰8Èâ€L*Îye!?ä.s[­Ìœ27É•	dà²®r—hÃ.QoË
+yÈiW&içòÜ»hkW:iíêk0Ô6#j¸Q¹¢‚ÌVR…â8üã¬b"?–›±MHmG G'¥ý“î/”¾´gùËB!ð„°k9l~æ|õ±h]ÛMÍ»£Î«rƒñÆØÖÀŒPÛºë1ú^Anng¸Rm2–¾´jÓ£Ñ¹¿Ä8$82œ«–·´]Õn››îžR˜¹½®çñbÙ§Ë­Zšé´NË;bÍÍÌüî£pHbÐ@Î{‚¹P>.Ð£ØÝ¹ŒÎé´g¡œ*;‡¡§Î f8§Ø)xn,ûc@À›`	ˆF0.˜æ³Ð6;ic¡-#–	ŒX,Ó¾‚9™<^l$Jµ´•ØJf{”Âêf³s½¥Sgç×{k¦Þ6%ÍÍè<”ËÊ	.5â>2ˆq±Qã!Éÿ+¹Ä€¨«Àç±PëZhµ®ÅM*-ÝÓ´¥8r…a5Û‚y©«iöùË¾lCj4[	k£GØóÀÐì{CEŠ\°"ríCáŠÅÕs¾ªqklh¨¶«ò'îÜ¹è¡›óŠíŽÅýþ¾O/YØ7¿wá"s÷T÷ïýêD59ãÁ»6æ”ƒ²Ð)ëø²à‘¢d´Ì³éàPiÖéõÈ¢{È‡O«ÍèŸSlÄB–\ª}ºB¡ô,=VYè&>’„-< þX€lZâh2:åèQ*töˆNÖ©YtWÌa•¬+K§ÒÍÝÈ"Z¼Ö’)Š ÁÁñûÉÒ¡Õ)ñ„¤¥6s|D®€¹ãñ½Ôä£ÑÑ`€ìY³Š›±_S¡ƒx<¿Í_oé©v™S×õy·tàðØCÛ¶½t ´}:ß¢·Ý¸+ïÅ(ûâÞ¼WOÓ ÓÛ@qËù?S5–SZÓó5ËðXÇ/œO\àˆ–xÑÏÆÃ”Ð¤žÌ|¢PO}þ Å>A»â¤è×‘L{aªa¨;I½ÆzÝ%dËòQâdñ( pM|97 -P°uAÉ'ZâãRÂs$Ç· ªeä®‡7äI|s0Or@oCz¶L@:9×åc†(ƒð!à	¼Ôë1W’	£5,k¾‰2†€ýÜTŠ-€µ­$úÆ††Ìo½ÅÅù2 phsx½¨ér?ƒáUß¿¬ž»\707QH&óë$=’ÖóøJa=ÿ°<ÇOH:9K\Ié<TB"ˆ’í€‹×9n+ÊÄÞJÌFQW•ÁY¬3/Y}˜N€‹tObÒë½§\0ÎrŠ°i}L°ÁJ0bÖdAþUŠ³9Ë™âí99Á%ñzxëéQ2XG¦c‹ƒÍ”›u0ãyÅLëFt¥ct¥qF1RßF-Oó6b}Ô•%S«8§¸^Ì%fÚÖÌvæNÍíÊÁ‰C0T¥“ã<QÜäµ
+e‰ƒîRöÜÕá\6¿öûó‡†Ÿ¸öÉç™­W}» pz]ÅÅÃ\|kÝ’ßÃç
+Œãg˜gøG‘*yÙ
+­6ZÎÌÍ3¤ñYYö(ÒG³q2ŠF¯‘ÕnR°éÉŠê×hÌ6˜á
+ó¡B.‚™Êev§YIð²¬Àæ“qá¬i…D)@|¦Y‚¥§ RAÏ]ìÃSRÂÊÁxÅ\gÄ
+rŠ–ãpþÏT~	ÁÎOÍ/#Î¶$â˜&.–á‡ à·ùÙ¶mCxåØS‚Ý¶¸ræŠcÙúÌg_`nÜ‹+ÇŽìY~]ßïÑ?m…ÿWÀ¨vÝ¹8rá †¼CðÁGœ¡Î*éÄÙdñ&ðWNÆ^Åœ`þ÷#u<u<DL‚«Ë‘8<DÛŠ» Im¤RC^ÃŸÑèq§P7q2“å$ì¹px!‹‘\Z!©²‰>õº;t·é{2¹Ag]ÉÐùƒ)8Â]ˆ:¢+IqŠ¢E…ZÌâVRH4Ò˜‘z:£@š7¸S°¬ÙÎV)Þ*èe_ÖvßÔñ	¬1i	Ø}?ºfoËÂ»Š‹Ë†ÌNgý¢ØÞÊ¡­‹ë‹KKÝÈ¼9zwóæ"¹àê[6 ¯]ÎôÙ„x —Å`×Ï2ÏòYu•,º¼º)0¼)ïeÎ®F»ò¼.Tê
+ÈîwÜYÇÜ.1•“a]gZ¡ƒE%¸aöó˜çÜpÌBN¶ McÆ?ÁLwFÑÃY”É„ õŒBN¦ˆä`·"FácºÞŸÂtV¶ê$]@·J×¥ã?{½¶³9>q$·QjS@5Ü“ä¡K6cLî‚˜=7víÓc×¿†ƒ8ÀÅ¿xœ‹_ü{=y}¥½WCã+Ð7Iö+üÛïº2`MçÂ÷ÉTƒæ£…ð]¨¾ì\ƒšà«Az:Dòž¬’„*¹±µ³k}+ú/¼nÍË
+endstream
+endobj
+29 0 obj
+<<
+/ProcSet [ /PDF /Text ]
+/ColorSpace <<
+/Cs1 30 0 R
+>>
+/Font <<
+/TT1 32 0 R
+>>
+>>
+endobj
+30 0 obj
+[ /ICCBased 31 0 R ]
+endobj
+31 0 obj
+<<
+/N 3
+/Alternate /DeviceRGB
+/Filter /FlateDecode
+/Length 2612
+>>
+stream
+x–wTSÙ‡Ï½7½Ð" %ôz	 Ò;HQ‰I€P†„&vDF)VdTÀG‡"cEƒ‚b×	òPÆÁQDEåÝŒk	ï­5óÞšýÇYßÙç·×Ùgï}×º Pü‚ÂtX€4¡XîëÁ\ËÄ÷XÀáffGøDÔü½=™™¨HÆ³öî.€d»Û,¿P&sÖÿ‘"7C$ 
+EÕ6<~&å”S³Å2ÿÊô•)2†12¡	¢¬"ãÄ¯lö§æ+»É˜—&ä¡YÎ¼4žŒ»PÞš%á£Œ¡\˜%àg£|e½TIš å÷(ÓÓøœL 0™_Ìç&¡l‰2Eî‰ò ”Ä9¼r‹ù9hž x¦gäŠ‰Ib¦×˜iåèÈfúñ³Sùb1+”ÃMáˆxLÏô´Ž0€¯o–E%Ym™h‘í­ííYÖæhù¿Ùß~Sý=ÈzûUñ&ìÏžAŒžYßlì¬/½ ö$Z›³¾•U ´m@åá¬Oï  ò ´Þœó†l^’Äâ'‹ììlsŸk.+è7ûŸ‚oÊ¿†9÷™ËîûV;¦?#I3eEå¦§¦KDÌÌ—Ïdý÷ÿãÀ9iÍÉÃ,œŸÀñ…èUQè”	„‰h»…<X.d
+„Õá6'~khu_ }…9P¸IÈo= C#$n?z}ë[1
+È¾¼h­‘¯s2zþçú\ŠnáLA"Sæödr%¢,£ß„lÁt 
+4.0,`€3pÞ  „€H–.Hi@²A>Ø 
+A1Øvƒjp ÔzÐN‚6p\WÀp€G@
+†ÁK0Þi‚ð¢Aª¤™BÖZyCAP8ÅC‰’@ùÐ&¨*ƒª¡CP=ô#tº]ƒú Ð 4ý}„˜ÓaØ ¶€Ù°;GÂËàDxœÀÛáJ¸>·Âáð ,…_Â“@ÈÑFXñDBX$!k‘"¤©Eš¤¹H‘qä‡¡a˜Æã‡YŒábVaÖbJ0Õ˜c˜VLæ6f3ù‚¥bÕ±¦X'¬?v	6›-ÄV``[°—±Øaì;ÇÀâp~¸\2n5®·×Œ»€ëÃá&ñx¼*Þï‚Ásðb|!¾
+ßÆ¿'	Zk‚!– $l$Tçý„Â4Q¨Ot"†yÄ\b)±ŽØA¼I&N“I†$R$)™´TIj"]&=&½!“É:dGrY@^O®$Ÿ _%’?P”(&OJEBÙN9J¹@y@yC¥R¨nÔXª˜ºZO½D}J}/G“3—ó—ãÉ­“«‘k•ë—{%O”×—w—_.Ÿ'_!Jþ¦ü¸QÁ@ÁS£°V¡Fá´Â=…IEš¢•bˆbšb‰bƒâ5ÅQ%¼’’·O©@é°Ò%¥!BÓ¥yÒ¸´M´:ÚeÚ0G7¤ûÓ“éÅôè½ô	e%e[å(ååå³ÊRÂ0`ø3R¥Œ“Œ»Œó4æ¹ÏãÏÛ6¯i^ÿ¼)•ù*n*|•"•f••ªLUoÕÕªmªOÔ0j&jajÙjûÕ.«Ï§ÏwžÏ_4ÿäü‡ê°º‰z¸újõÃê=ê“š¾U—4Æ5šnšÉšåšç4Ç´hZµZåZçµ^0•™îÌTf%³‹9¡­®í§-Ñ>¤Ý«=­c¨³Xg£N³Î]’.[7A·\·SwBOK/X/_¯Qï¡>QŸ­Ÿ¤¿G¿[ÊÀÐ Ú`‹A›Á¨¡Š¡¿aža£ác#ª‘«Ñ*£Z£;Æ8c¶qŠñ>ã[&°‰I’IÉMSØÔÞT`ºÏ´Ïkæh&4«5»Ç¢°ÜYY¬FÖ 9Ã<È|£y›ù+=‹X‹Ý_,í,S-ë,Y)YXm´ê°úÃÚÄšk]c}Ç†jãc³Î¦Ýæµ­©-ßv¿í};š]°Ý»N»Ïöö"û&û1=‡x‡½÷Øtv(»„}Õëèá¸ÎñŒã'{'±ÓI§ßYÎ)ÎÎ£ðÔ-rÑqá¸r‘.d.Œ_xp¡ÔUÛ•ãZëúÌM×çvÄmÄÝØ=Ùý¸û+K‘G‹Ç”§“çÏ^ˆ—¯W‘W¯·’÷bïjï§>:>‰>>¾v¾«}/øaýývúÝó×ðçú×ûO8¬	è
+¤FV>2	uÃÁÁ»‚/Ò_$\ÔBüCv…<	5]ús.,4¬&ìy¸Ux~xw-bEDCÄ»HÈÒÈG‹KwFÉGÅEÕGME{E—EK—X,Y³äFŒZŒ ¦={$vr©÷ÒÝK‡ãìâ
+ãî.3\–³ìÚrµå©ËÏ®_ÁYq*ßÿ‰Â©åL®ô_¹wå×“»‡û’çÆ+çñ]øeü‘—„²„ÑD—Ä]‰cI®IIãOAµàu²_òä©””£)3©Ñ©Íi„´ø´ÓB%aŠ°+]3='½/Ã4£0CºÊiÕîU¢@Ñ‘L(sYf»˜ŽþLõHŒ$›%ƒY³j²ÞgGeŸÊQÌæôäšänËÉóÉû~5f5wug¾vþ†üÁ5îk­…Ö®\Û¹Nw]Áºáõ¾ëm mHÙðËFËeßnŠÞÔQ Q°¾`h³ïæÆB¹BQá½-Î[lÅllíÝf³­jÛ—"^ÑõbËâŠâO%Ü’ëßY}WùÝÌö„í½¥ö¥ûwàvwÜÝéºóX™bY^ÙÐ®à]­åÌò¢ò·»Wì¾Va[q`id´2¨²½J¯jGÕ§ê¤êšæ½ê{·íÚÇÛ×¿ßmÓÅ>¼È÷Pk­AmÅaÜá¬ÃÏë¢êº¿g_DíHñ‘ÏG…G¥ÇÂuÕ;Ô×7¨7”6Â’Æ±ãqÇoýàõC{«éP3£¹ø8!9ñâÇøïž<ÙyŠ}ªé'ýŸö¶ÐZŠZ¡ÖÜÖ‰¶¤6i{L{ßé€ÓÎ-?›ÿ|ôŒö™š³ÊgKÏ‘Îœ›9Ÿw~òBÆ…ñ‹‰‡:Wt>º´äÒ®°®ÞË—¯^ñ¹r©Û½ûüU—«g®9];}}½í†ýÖ»ž–_ì~iéµïm½ép³ý–ã­Ž¾}çú]û/Þöº}åŽÿ‹úî.¾{ÿ^Ü=é}ÞýÑ©^?Ìz8ýhýcìã¢'
+O*žª?­ýÕø×f©½ôì ×`Ï³ˆg†¸C/ÿ•ù¯OÃÏ©Ï+F´FêG­GÏŒùŒÝz±ôÅðËŒ—Óã…¿)þ¶÷•Ñ«Ÿ~wû½gbÉÄðkÑë™?JÞ¨¾9úÖömçdèäÓwiï¦§ŠÞ«¾?öý¡ûcôÇ‘éìOøO•Ÿ?w|	üòx&mfæß÷„óû
+endstream
+endobj
+32 0 obj
+<<
+/Type /Font
+/Subtype /TrueType
+/BaseFont /AAAAAB+HelveticaNeue
+/FontDescriptor 33 0 R
+/Encoding /MacRomanEncoding
+/FirstChar 32
+/LastChar 117
+/Widths [ 278 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 574 0 0 0 0 0 0 0 0 0 0 0 0 537 0 537 593 537 0 574 0 222 0 0 0 0 556 574 0 0 0 500 315 556 ]
+>>
+endobj
+33 0 obj
+<<
+/Type /FontDescriptor
+/FontName /AAAAAB+HelveticaNeue
+/Flags 32
+/FontBBox [ -951 -481 1987 1077 ]
+/ItalicAngle 0
+/Ascent 952
+/Descent -213
+/CapHeight 714
+/StemV 95
+/Leading 28
+/XHeight 517
+/StemH 80
+/AvgWidth 447
+/MaxWidth 2225
+/FontFile2 34 0 R
+>>
+endobj
+34 0 obj
+<<
+/Length1 4960
+/Filter /FlateDecode
+/Length 2844
+>>
+stream
+xµXml[Õ>çØŽ'q|m_Û‰íä^_Û±síú+®ÓÆiÒHKSlJZÒ44(TumU¥‰
+òcÚÐ
+“61‰}j
+ÒÔ¹F•Ø`cLêŸmŠÐ~lÒ„BSAtÏ¹vLZ:TMì¶Ï=ï9÷Ü÷¾ïsÞ÷=ÇY}ìkË¤›\ :R^:½x†hW‡„æ7KgWy‹‹þ7÷CgNžÖº„^%D9ùð5ûF=!]×W–O4ûäS´¹4ûtÚÀÊéÕsÍ¾áŸh?ºÔzÞñwôN/žk}Ÿl /=²xz¹9ß^@9óèã«Í¾íßhËg[nÍ§Uôïj>Ûq§-d/aÚXó>@ÐÕG´þø×y·þXïØ‡TÐq»Èå½ò†¼ó·!áÓ™­Aãkú,º-=Ú;ºú8ñš^ÆóÆ×¸–›.K8â´7qÆé« ·Dò$N‰½qò*žì¿y¨Aôøç‰×	•*ß<åž¬3:x‹ÿ?Kî‡(Ü!]Ì@ºÙ›DÀãÄltÎU_¦ôÛµ:½ñT}’ø®ÀZÝ±£CP•¤Ê©Éuú :,˜I—¦ÖuÁ©ƒU¥&­Ik3'Ö¤)ieñÄº>¨µx°¼VKIëäÞê)ÜUåõrÍÓ—kµèÑs=xÓ×jÐðÕ–´ÚPj“‰Yi]š«¨®_˜ô¬—'kY–*ëWçªëW'=r­†YmKa1w¿i³6wÄðÜÔÔr/t@EmmëD…äõ«kkž5x¢(r’Ö <åstÁJ–çªüQY‘=|@‘vÔ&¡»31{oµKdn‰ùs”’É”vµÅÜn˜×¥QÚó%Qj¹J{ïˆRkÛÒ›(`³•Sj»=¥ÊÚf¸|†/4¾p†í71ìøb†Å¶Ý0Ò	kEa×—Ä°ûNî»#†ûÛ–ÞÄ°6÷s†½m†ËžuÒZ0|á–%ÿ5†ÿWÊ};(§×I†:QûJ„±>Ðp Õ–H€¼C*,AÊxÀÜA:J:yõ†¶ª[7é —Ñ—ÈáÏÕ;ÿ_®fÍ¾jõÄ ›1¦ö¤NbnÉ]ØÙz4yšL“Gè9ú.{š} {Q÷–Þ¡ÿ¥¡jø©ác<g$C(}‹ýeÚH–yíF¹I¡¶&+êÏ5 uu×1j½‚Os©sƒ  Vª¨ƒ)4—j­0=Ðã|/ aO¸>¬RYí‚,ÐK[¤™ÌÖIöüæ³ìÒf‘½vá7G}7’pF¢ƒE:+ÿZªŸÚ@L3ºkÃª]È™¬,~pìýÍß²'7/²'çæ4ß7>df&a²‡>À}{… ³‡¸!Å ¹ Õ‰ŠðÓšð…q! L‡‡€³€iaÂ@ž‚ð,Àê¤ Ç$pr;gÆ…þpKªzUpÃ7&Ûœ9EAbjsÆø vçö€‰˜ø@\2lÅ:	B·$Â„g \âm‚à"@˜ªÀ
+p0ÁÎ ,ÜÀNI®C —IP$a ìîN_4_/Bx`øÕ´¤AÔ¶MãX‚`‡âe-Tñ'YvW‰åKºì®$SüF¥¤Ë¤˜(8œ™t>l1ˆŽ–I—X–™a9¬,ä”ÝIÏ€º[Vv{E9êÈMëæY`ì®„R)øŽ®Þ5ë®âHÒ'xŽØXÈÆz‚±XÐêÏ‡ÅÖa4öô¹½~[G´8¼'j3†¶>ðÞèî2v:‚’è³™\JÔ†@|!&èÇˆ	…<Ñ 3]Z8y­¬¼+ïÅÊ{±ò^¬¼+ïÅÊ{±ò^rxx	¸¼ôðhø„ l4À§USé²òh•ÛÑJ@½KàØ@d’:ÅoaM*ryå3æ2i'ý~Õ½+1þÀøÀàø‘Ñ¥Ç-÷™öíŽŒk°”Ì•é±äÞ„Ÿ]Yœ
+­<8¶GÊNÂ3ŽûÈ¸Ì‚²“y¥N†8"\ã™$Â„!Àày¾¡yNð˜Àsœ])à0ÀÏ¸g‹ÀsÀKÀeàu å9çø$âË	­fh5C+—ÝÝ-99+âÄOD-’ùŒÄ5dµˆá^D 7®œùî\öY‡Õ<BI‡±”dA”›©Ëˆç­±x¢¶	¡±xt<l§ß™g–h2é­úFkc¹ûE¶š.øåÜ¾P`*ï—r•·Ù›[¹í¦øÌñ|þøþD(>ÅÑ¸Ó!>Ì`ãHGOd5ÌqÀ4¶9tÀ~
+¯Ún´Ý)¬}/v“m?ú±ú\îÇ‹j¸L19À_à1 7ÃÕZü¼œã	ƒ @Âäè¶þÂœ¡¬,eÃ®C‡º*¹X)b£ô[LÌ©dk6X:Rª®Ò]ÙˆËÎý"“ö¦Æý©•j12}|tôÄt¤ªù“¢[ð'BÆÈ¯ÈãnÍ”¤fªzË,³
+ð£€åÐãµ‚¶J|T¼¦EH’'IDH’D„$!IDHÒ,/¡½¼´"$‰iVßNjzeÄ…„„à„”6Àœš¹)˜eÄžÄe#ä(49Šh
+Š¨$Qc>KœŒØŠŒ°¢±nÕŸí ¡[sÔuPÝû@Áí9<’®9™‰‰É°‡Î³Èølà«ïÇ
+~‹‰F
+ŠUŒ&è_÷Çã™{“ÙcûbCÃþøtÆ×é\±‘€õüw•â”œÜ5(e÷øÓE…ÇLñ<òï¡àob;yÕƒWîiwƒ6¡H^Ù³Šb{~~ž_YYØü?p ¢ŒÛ{X7©ìÜøY×¬YhÔ"´ó$ròè»ÚNÉ²ü7i†Øùwð-œ"—x¬•lyÞ*†ÕÂ¼›Ì<žeÌ°ù	(£	waxëEz(VI{ÜÎ‹~ØcG®þ¡N"XÁ(Xà€üåÕ’(´ >Ì(¯o#ß°ÓyðãÎLú€(Pf€p
+xx¸ü¸üèáu¹¯ñEá5FiÕ…órK	ooOEv¾/1*Ë£‰¾íö~©|t¼´P–¤òBiühY¢,5“îïOÏ¤R3j¿:“*Ÿ‰FgŽ‹K3±ØÌ†’Aì;#ägm@oàÜÐ¬.ŒR!KZv¨)Ík^c›mz­Â|^«ðZ…×*¼Váµ
+¯Ux­Âk^«ðZ…×*¼ÆÏ3pÈ+T­tAãù–kU§>$ý3ü€ÀÏU|§jPµ¼Âf6ÂIlêÍ‚ìúlÓo§à*ß³ïŽ‡ïÙö¥Æ¥±áA‡¶‹Q¿“ÍëüÅý	%¯¤g«³iw0áèWÃîïÚzC¥T0-;°Û}NG_oG§CîKíö
+J!œ.
+¢_vZ;Ì®0xì™>öäªó­™ÆO«<'ŒhyírÁ•È<û<ûø²·Uy$ðs4
+=&L4 ¯iY)*bF@0ŒÒ¬v¬Áóò|µjñ¥ä‰°£Ïb8É/¼0»õ«@ÂÝ9«3ÛzéÄ,V–ç.Öú=¤±›hhqþ‰n|îV{ø¤&¹P1h»â6wÎylBÖq&Ä«Œ=P+z¡,—øY*—Ïˆô½™\<äA*om4™Ýú9Ù34ŒLæ¹¬]7¾GÒMé–»}Îƒ“¨òûp”ÜO¾Bƒ¨÷÷áPÉ/Jl ¿:øŸg&øµ'>½üðÙåÕSK‹w/ã/kä? yÕy
+endstream
+endobj
+35 0 obj
+<<
+/Filter /FlateDecode
+/Length 202
+>>
+stream
+xUŽ±ŽÂ0Dû|Å”Pœñ&v¼nÑÐ!YºâD‚á,GÁáÿoÃ8´ÅìHo43b‡ZÎz«jRìqøBÆj]]Ý¯tÂ=€^íÓ\fS}hEÚ{¶ßìN÷&Û(Ãž<l«Z_û†Y5š\CÊi7wWÿ»çqÒ=Êˆù¥WØ9«Ø°lìñ@àOBUTÂ	ßX„¥ „E,n9uÃ1âER>#•r‹)ãó0¦4ä²Äa‹Mí»_{ùFõ
+endstream
+endobj
+xref
+0 36
+0000000000 65535 f 
+0000000015 00000 n 
+0000000074 00000 n 
+0000000114 00000 n 
+0000000163 00000 n 
+0000000301 00000 n 
+0000000326 00000 n 
+0000018780 00000 n 
+0000019223 00000 n 
+0000019333 00000 n 
+0000019369 00000 n 
+0000022077 00000 n 
+0000022246 00000 n 
+0000022503 00000 n 
+0000027557 00000 n 
+0000027852 00000 n 
+0000028227 00000 n 
+0000028466 00000 n 
+0000034602 00000 n 
+0000035047 00000 n 
+0000035159 00000 n 
+0000035196 00000 n 
+0000037904 00000 n 
+0000038073 00000 n 
+0000038330 00000 n 
+0000043384 00000 n 
+0000043679 00000 n 
+0000044054 00000 n 
+0000044293 00000 n 
+0000050429 00000 n 
+0000050529 00000 n 
+0000050566 00000 n 
+0000053279 00000 n 
+0000053653 00000 n 
+0000053921 00000 n 
+0000056853 00000 n 
+trailer
+<<
+/Size 36
+/Root 3 0 R
+/Info 2 0 R
+>>
+startxref
+57128
+%%EOF

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -337,13 +337,15 @@ class Test(unittest.TestCase):
 
     def test_pr_1195(self):
         """
-        In certain scenarios, annotations may include invalid or extraneous data that can
-        obstruct the annotation processing workflow.
-        To mitigate this, the raise_unicode_errors parameter in the PDF initializer
-        and the .open() method provides a configurable option to bypass these errors and
-        generate warnings instead, ensuring smoother handling of such anomalies.
+        In certain scenarios, annotations may include invalid or extraneous
+        data that can obstruct the annotation processing workflow.  To mitigate
+        this, the raise_unicode_errors parameter in the PDF initializer and the
+        .open() method provides a configurable option to bypass these errors
+        and generate warnings instead, ensuring smoother handling of such
+        anomalies.
 
-        The following tests verifies the functionality of the raise_unicode_errors parameter.
+        The following tests verifies the functionality of the
+        raise_unicode_errors parameter.
         """
         path = os.path.join(HERE, "pdfs/annotations-unicode-issues.pdf")
         with pdfplumber.open(path) as pdf, pytest.raises(UnicodeDecodeError):

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -9,6 +9,8 @@ except ModuleNotFoundError:
     resource = None
 import unittest
 
+import pytest
+
 import pdfplumber
 
 logging.disable(logging.ERROR)
@@ -332,3 +334,24 @@ class Test(unittest.TestCase):
                 ["Bar10", "Bar11", "Bar12"],
                 ["", "", ""],
             ]
+
+    def test_pr_1195(self):
+        """
+        In certain scenarios, annotations may include invalid or extraneous data that can
+        obstruct the annotation processing workflow.
+        To mitigate this, the raise_unicode_errors parameter in the PDF initializer
+        and the .open() method provides a configurable option to bypass these errors and
+        generate warnings instead, ensuring smoother handling of such anomalies.
+
+        The following tests verifies the functionality of the raise_unicode_errors parameter.
+        """
+        path = os.path.join(HERE, "pdfs/annotations-unicode-issues.pdf")
+        with pdfplumber.open(path) as pdf, pytest.raises(UnicodeDecodeError):
+            for _ in pdf.annots:
+                pass
+
+        with pdfplumber.open(path, raise_unicode_errors=False) as pdf, pytest.warns(
+            UserWarning
+        ):
+            for _ in pdf.annots:
+                pass


### PR DESCRIPTION
In certain scenarios, annotations may include invalid or extraneous data that can obstruct the annotation processing workflow. To mitigate this, the `warn_unicode_error` parameter in the `PDF` initializer and the `.open()` method provides a configurable option to bypass these errors and generate warnings instead, ensuring smoother handling of such anomalies. 

Example warning, if activated:

```
UserWarning: Could not decode contents for annotation. Annotation contents will be missing.
```