### PR TITLE
Fix broken link to Anssi Nurminen's master's thesis in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Note: The methods above are built on Pillow's [`ImageDraw` methods](http://pillo
 
 ## Extracting tables
 
-`pdfplumber`'s approach to table detection borrows heavily from [Anssi Nurminen's master's thesis](http://dspace.cc.tut.fi/dpub/bitstream/handle/123456789/21520/Nurminen.pdf?sequence=3), and is inspired by [Tabula](https://github.com/tabulapdf/tabula-extractor/issues/16). It works like this:
+`pdfplumber`'s approach to table detection borrows heavily from [Anssi Nurminen's master's thesis](https://trepo.tuni.fi/bitstream/handle/123456789/21520/Nurminen.pdf?sequence=3), and is inspired by [Tabula](https://github.com/tabulapdf/tabula-extractor/issues/16). It works like this:
 
 1. For any given PDF page, find the lines that are (a) explicitly defined and/or (b) implied by the alignment of words on the page.
 2. Merge overlapping, or nearly-overlapping, lines.


### PR DESCRIPTION
The link to Anssi Nurminen's master's thesis in the [README.md](https://github.com/jsvine/pdfplumber/blob/stable/README.md#extracting-tables) is currently broken.

Replaced with:
https://trepo.tuni.fi/bitstream/handle/123456789/21520/Nurminen.pdf?sequence=3

That I found here:
https://urn.fi/URN:NBN:fi:tty-201305231166

I wasn’t sure if this change requires an update to the [CHANGELOG.md](https://github.com/jsvine/pdfplumber/blob/develop/CHANGELOG.md), so I have not added one.