### PR TITLE
test_issue_1089: update wording regarding pypdfium2

### DIFF
--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -285,10 +285,11 @@ class Test(unittest.TestCase):
 
     def test_issue_1089(self):
         """
-        Page.to_image() leaks file descriptors
+        Page.to_image() binds file descriptors.
 
-        This is because PyPdfium2 leaks file descriptors.  Explicitly
-        close the `PdfDocument` to prevent this.
+        This is because pypdfium2 binds file descriptors, and garbage collection may
+        be too lazy. Explicitly close the `PdfDocument` to prevent running out of file
+        descriptors.
         """
         # Skip test on platforms without getrlimit
         if resource is None:


### PR DESCRIPTION
pypdfium2 doesn't actually "leak" file descriptors.
It's just that if the caller doesn't close the PdfDocument explicitly, we rely on garbage collection / finalization to do that, which may happen too late. Update the wording accordingly.

See also https://github.com/jsvine/pdfplumber/issues/1089#issuecomment-2007961627 for background.