### PR TITLE
Fix pdfminer.six dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pdfminer.six>=20240706
+pdfminer.six>=20250324
 Pillow>=9.1
 pypdfium2>=4.18.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pdfminer.six==20231228
+pdfminer.six>=20240706
 Pillow>=9.1
 pypdfium2>=4.18.0


### PR DESCRIPTION
The latest version of `pdfminer.six` had issues with certain PDF files.  

The pdfplumber code was forced to declare a dependency on an older version: `pdfminer.six==20231228`.  
This caused problems when trying to use multiple different parsers, with different versions, in the same project.  

I [fixed the bug](https://github.com/pdfminer/pdfminer.six/pull/1081) in `pdfminer.six`. The [latest released version](https://pypi.org/project/pdfminer.six/) includes this modification, so it is no longer necessary to depend on an older version.  

This fix updates the dependency on `pdfminer.six` to remove this limitation.