### PR TITLE
Upgrade pdfminer.six from 20250506 to 20251107

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pdfminer.six==20250506
+pdfminer.six==20251107
 Pillow>=9.1
 pypdfium2>=4.18.0


### PR DESCRIPTION
Handle security issue:
https://github.com/pdfminer/pdfminer.six/security/advisories/GHSA-f83h-ghpp-7wcc

All tests passed on python 3.12.3 in venv with updated `requirements.txt` and:

```bash
pip install -e .
pip install requirements-dev.txt
sudo apt install ghostscript
pytest -v
```