### PR TITLE
Adjust text-strategy vertical edges to nearest word gap

### DIFF
--- a/pdfplumber/table.py
+++ b/pdfplumber/table.py
@@ -141,6 +141,57 @@ def words_to_edges_h(
     return edges
 
 
+def _find_nearest_gap_midpoint(edge_x: T_num, words: T_obj_list) -> T_num:
+    """
+    Find the midpoint of the nearest gap between words for an edge position.
+
+    If edge_x intersects a word, find the closest gap (empty space between words)
+    and return its midpoint. If no gap is found, return the original position.
+    """
+    if not words:
+        return edge_x
+
+    # Get all unique x-boundaries from words, sorted
+    boundaries = sorted(
+        set(w["x0"] for w in words) | set(w["x1"] for w in words)
+    )
+
+    if len(boundaries) < 2:
+        return edge_x
+
+    # Build a set of intervals covered by words for fast lookup
+    word_intervals = [(w["x0"], w["x1"]) for w in words]
+
+    # Find gaps between consecutive boundaries
+    gaps: List[Tuple[T_num, T_num]] = []
+    for i in range(len(boundaries) - 1):
+        left, right = boundaries[i], boundaries[i + 1]
+        # Check if any word spans this range
+        is_covered = any(
+            w_x0 <= left and w_x1 >= right for w_x0, w_x1 in word_intervals
+        )
+        if not is_covered:
+            gaps.append((left, right))
+
+    if not gaps:
+        return edge_x
+
+    # Find the gap whose midpoint is nearest to edge_x
+    best_gap = min(gaps, key=lambda g: abs((g[0] + g[1]) / 2 - edge_x))
+    return (best_gap[0] + best_gap[1]) / 2
+
+
+def _adjust_edge_if_intersects(edge_x: T_num, words: T_obj_list) -> T_num:
+    """
+    If edge_x intersects any word, move it to the nearest gap midpoint.
+    """
+    # Check if edge intersects any word
+    intersects = any(w["x0"] < edge_x < w["x1"] for w in words)
+    if not intersects:
+        return edge_x
+    return _find_nearest_gap_midpoint(edge_x, words)
+
+
 def words_to_edges_v(
     words: T_obj_list, word_threshold: int = DEFAULT_MIN_WORDS_VERTICAL
 ) -> T_obj_list:
@@ -182,25 +233,24 @@ def words_to_edges_v(
     min_top = min(map(itemgetter("top"), sorted_rects))
     max_bottom = max(map(itemgetter("bottom"), sorted_rects))
 
+    # Generate initial edge positions
+    edge_positions = [b["x0"] for b in sorted_rects] + [max_x1]
+
+    # Adjust any edge that intersects a word to the nearest gap midpoint
+    adjusted_positions = [
+        _adjust_edge_if_intersects(pos, words) for pos in edge_positions
+    ]
+
     return [
         {
-            "x0": b["x0"],
-            "x1": b["x0"],
+            "x0": pos,
+            "x1": pos,
             "top": min_top,
             "bottom": max_bottom,
             "height": max_bottom - min_top,
             "orientation": "v",
         }
-        for b in sorted_rects
-    ] + [
-        {
-            "x0": max_x1,
-            "x1": max_x1,
-            "top": min_top,
-            "bottom": max_bottom,
-            "height": max_bottom - min_top,
-            "orientation": "v",
-        }
+        for pos in adjusted_positions
     ]
 
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -250,3 +250,77 @@ class Test(unittest.TestCase):
             assert t[-2][-2] == "Uncommon"
 
             assert len(page.extract_tables({"vertical_strategy": "lines_strict"})) == 0
+
+class TestEdgeAdjustmentIntegration(unittest.TestCase):
+    """Integration tests for edge adjustment with realistic table scenarios.
+
+    These tests simulate real-world cases where table headers are longer than
+    the data columns below them, which previously caused edges to incorrectly
+    intersect the header text.
+
+    Key insight: words_to_edges_v clusters words by x0, x1, or center, and needs
+    at least `word_threshold` (default 3) words aligned to create an edge.
+    Bounding boxes from clusters that overlap get condensed, so we need clusters
+    that DON'T overlap with larger clusters to trigger the bug.
+    """
+
+    def _make_word(self, x0, x1, top, bottom, text=""):
+        """Helper to create a word-like dict with all typical fields."""
+        return {
+            "x0": x0,
+            "x1": x1,
+            "top": top,
+            "bottom": bottom,
+            "text": text,
+            "doctop": top,
+            "upright": True,
+        }
+
+    def test_short_aligned_data_under_wide_header(self):
+        """Test that edges from short aligned data don't cut through wide headers.
+
+        Creates a scenario where column 2's data cluster creates an edge
+        that would fall inside column 1's wide header.
+
+        The key is that the column 2 data cluster bbox must NOT overlap
+        with any previously accepted condensed bbox, so it doesn't get
+        filtered out by the overlap check.
+
+        Layout:
+        | Wide Header Here       | Col2 |
+        |                   data | val  |  (many rows)
+
+        Column 1 header: x=10-200
+        Column 1 data: x=160-190 (right-aligned, doesn't share x0 with header)
+        Column 2 data: x=100-120 (x0=100 is inside the header 10-200)
+
+        The column 2 cluster at x0=100 won't overlap with column 1 data cluster
+        (which is at x=160-190), so it won't be condensed away.
+        """
+        words = [
+            # Wide header spanning most of the width
+            self._make_word(10, 200, 0, 10, "Wide Header Here"),
+            self._make_word(250, 300, 0, 10, "Col2"),
+        ]
+
+        # Add many rows where:
+        # - Column 1 data is right-aligned (x=160-190), NOT overlapping with col2
+        # - Column 2 data starts at x=100, which is INSIDE the header (10-200)
+        #   but does NOT overlap with column 1 data bbox (160-190)
+        for i in range(10):
+            y_top = 20 + i * 15
+            y_bottom = y_top + 10
+            # Column 1: right-aligned data
+            words.append(self._make_word(160, 190, y_top, y_bottom, "data"))
+            # Column 2: data whose x0 (100) falls inside header (10-200)
+            words.append(self._make_word(100, 130, y_top, y_bottom, "val"))
+
+        edges = table.words_to_edges_v(words, word_threshold=3)
+        x_positions = sorted([e["x0"] for e in edges])
+
+        # The bug: without the fix, there would be an edge at x=100
+        # which is inside "Wide Header Here" (10-200)
+        for x in x_positions:
+            assert not (10 < x < 200), (
+                f"Edge at x={x} incorrectly intersects 'Wide Header Here' (10-200)"
+            )


### PR DESCRIPTION
When using vertical_strategy="text", edges are placed at cluster boundaries which can fall inside wider words (e.g., a long header with short data below). This adjusts such edges to the midpoint of the nearest gap between words, preventing table columns from splitting text.

Example.  See the header "Expense" in column 5.

### Before
<img width="866" height="306" alt="image" src="https://github.com/user-attachments/assets/b78b1e00-1757-43b4-8609-dfb13c6fe695" />

### After
<img width="866" height="306" alt="image" src="https://github.com/user-attachments/assets/20dc0e55-f122-4e40-93e4-0e3184ad5936" />
