### PR TITLE
Preserve explicit table lines outside the natural edge span (fixes #1335)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+### Fixed
+- Fix `extract_table` dropping columns when `vertical_strategy="explicit"` is paired with text- or lines-derived horizontal edges that don't span the full range of the explicit vertical lines (and symmetrically for explicit horizontal lines). ([#1335](https://github.com/jsvine/pdfplumber/issues/1335))
+
+### Changed
 - Upgrade `pdfminer.six` from `20251230` to `20260107`. ([07a5ff6](https://github.com/jsvine/pdfplumber/commit/07a5ff6))
 
 ## 0.11.9 — 2026-01-05

--- a/README.md
+++ b/README.md
@@ -574,6 +574,7 @@ Many thanks to the following users who've contributed ideas, features, and fixes
 - [Brandon Roberts](https://github.com/brandonrobertz)
 - [@ennamarie19](https://github.com/ennamarie19)
 - [Anton Ilin](https://github.com/bronislav)
+- [Filippo Mattia Menghi](https://github.com/Cyberfilo)
 
 ## Contributing
 

--- a/pdfplumber/table.py
+++ b/pdfplumber/table.py
@@ -694,6 +694,31 @@ class TableFinder(object):
 
         h = h_base + h_explicit
 
+        # Make sure horizontal edges span the x-range of any explicit vertical
+        # lines (and vertical edges span the y-range of any explicit horizontal
+        # lines), so that columns/rows defined by user-supplied lines aren't
+        # dropped at the intersection step when the surrounding text or detected
+        # lines don't reach them. See issue #1335.
+        if v_explicit and h:
+            vx_min = min(e["x0"] for e in v_explicit)
+            vx_max = max(e["x0"] for e in v_explicit)
+            for e in h:
+                if e["x0"] > vx_min:
+                    e["x0"] = vx_min
+                if e["x1"] < vx_max:
+                    e["x1"] = vx_max
+                e["width"] = e["x1"] - e["x0"]
+
+        if h_explicit and v:
+            hy_min = min(e["top"] for e in h_explicit)
+            hy_max = max(e["bottom"] for e in h_explicit)
+            for e in v:
+                if e["top"] > hy_min:
+                    e["top"] = hy_min
+                if e["bottom"] < hy_max:
+                    e["bottom"] = hy_max
+                e["height"] = e["bottom"] - e["top"]
+
         edges = list(v) + list(h)
 
         edges = merge_edges(

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -173,6 +173,78 @@ class Test(unittest.TestCase):
         assert table.words_to_edges_h([]) == []
         assert table.words_to_edges_v([]) == []
 
+    def test_issue_1335_explicit_outside_text_span(self):
+        """
+        See issue #1335.  When explicit vertical lines fall outside the
+        natural x-span of text-derived horizontal edges, the corresponding
+        columns must still be recovered.
+        """
+
+        class FakePage:
+            def __init__(self, words, bbox=(0, 0, 600, 800)):
+                self._words = words
+                self.bbox = bbox
+                self.edges = []
+
+            def extract_words(self, **_kwargs):
+                return self._words
+
+        def word(text, x0, top):
+            width = 8 * len(text)
+            return {
+                "text": text,
+                "x0": x0,
+                "x1": x0 + width,
+                "top": top,
+                "bottom": top + 12,
+                "doctop": top,
+                "upright": True,
+                "height": 12,
+                "width": width,
+                "fontname": "Helvetica",
+                "size": 10,
+            }
+
+        # Three rows of three columns; the last column's text is narrow
+        # and ends well before the rightmost explicit vertical (x=500).
+        # The leftmost explicit vertical (x=50) sits to the left of any
+        # text.  Both columns must still be detected.
+        rows = [
+            [("Alpha", 60), ("100", 210), ("X", 360)],
+            [("Beta", 60), ("200", 210), ("YY", 360)],
+            [("Gamma", 60), ("300", 210), ("Z", 360)],
+        ]
+        words = [
+            word(text, x0, 100 + 30 * row_idx)
+            for row_idx, row in enumerate(rows)
+            for text, x0 in row
+        ]
+        page = FakePage(words)
+        tf = table.TableFinder(
+            page,
+            {
+                "vertical_strategy": "explicit",
+                "horizontal_strategy": "text",
+                "explicit_vertical_lines": [50, 200, 350, 500],
+                "intersection_tolerance": 5,
+                "snap_tolerance": 3,
+                "join_tolerance": 5,
+            },
+        )
+        xs = sorted({p[0] for p in tf.intersections})
+        assert xs == [50, 200, 350, 500]
+        assert len(tf.tables) == 1
+        # 3 data rows × 3 columns of cells must all be present.
+        cell_xs_by_row = {}
+        for x0, top, _x1, _bottom in tf.tables[0].cells:
+            cell_xs_by_row.setdefault(top, set()).add(x0)
+        full_rows = [
+            top
+            for top, xs_in_row in cell_xs_by_row.items()
+            if {50, 200, 350}.issubset(xs_in_row)
+        ]
+        assert len(full_rows) >= 3
+
     def test_order(self):
         """
         See issue #336


### PR DESCRIPTION
## What

When `page.extract_table(...)` is called with `vertical_strategy="explicit"` (or `horizontal_strategy="explicit"`), the user-supplied lines define the column / row boundaries.  Edges of the opposite orientation are still derived from text clustering or detected page lines, and those are only as wide as the underlying objects.

`words_to_edges_h` (and the `lines` variants for horizontal edges) span just `min_x0..max_x1` of the rows they detect.  `edges_to_intersections` then keeps only the vertical edges whose `x0` falls inside `[h.x0 - x_tol, h.x1 + x_tol]`.  When an explicit vertical line sits outside that span — common when the leftmost or rightmost column is narrow, right-aligned, or contains only short / multi-line text — the intersection is rejected and the entire column collapses into its neighbour (or disappears entirely if it is the only one beyond the span).

## Fix

In `TableFinder.get_edges()`, after the base + explicit edges are concatenated, extend each horizontal edge's `x0` / `x1` to cover the x-range of any explicit vertical lines (and symmetrically extend vertical edges' `top` / `bottom` to cover any explicit horizontals).

Explicit edges already span the full page when supplied as floats, and span their declared bbox when supplied as dicts — so this only ever **widens** edges derived from words or page lines, never narrows or moves anything.  Tables that do not use explicit lines are untouched.

## Repro / test

Added `test_issue_1335_explicit_outside_text_span` in `tests/test_table.py`.  It constructs a three-row, three-column layout with a narrow last column (text ends ~130 px before the rightmost explicit vertical) and asserts that:

- all four explicit vertical positions produce intersections;
- the resulting table contains rows with all three column-cells present.

Without the patch, only the inner two explicit verticals produce intersections and the table collapses to a single column.  Running the new test against `develop`:

```
$ pytest tests/test_table.py::Test::test_issue_1335_explicit_outside_text_span
... FAILED  (assert [200.0, 350.0] == [50, 200, 350, 500])
```

With the patch:

```
$ pytest tests/test_table.py::Test::test_issue_1335_explicit_outside_text_span
... PASSED
```

## Verification

- `make tests` — 165 passed (the pre-existing `test_repair.py::test_from_issue_932` failure on systems without Ghostscript is unchanged).
- `make lint` — clean (flake8, mypy --strict, black --check, isort --check).
- Added entry under `## Unreleased` in `CHANGELOG.md` and added myself to the contributors list per `CONTRIBUTING.md`.

Fixes #1335.