### PR TITLE
Fix `to_image()` omitting filled AcroForm widget values (closes #1367)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+- Fix `to_image()` / `get_page_image` omitting filled AcroForm widget values from the rasterized PIL bitmap. Calls `pypdfium2.PdfDocument.init_forms()` after open and before page load so PDFium's form-rendering layer (`FPDF_FFLDraw`) draws filled fields. Resolves [#1367](https://github.com/jsvine/pdfplumber/issues/1367).
 - Upgrade `pdfminer.six` from `20251230` to `20260107`. ([07a5ff6](https://github.com/jsvine/pdfplumber/commit/07a5ff6))
 
 ## 0.11.9 — 2026-01-05

--- a/pdfplumber/display.py
+++ b/pdfplumber/display.py
@@ -58,6 +58,12 @@ def get_page_image(
     except pypdfium2.PdfiumError as e:
         raise MalformedPDFException(e)
 
+    # Initialize the PDFium form environment before loading the page so
+    # filled AcroForm widgets are drawn by FPDF_FFLDraw at render time.
+    # init_forms() must run after open and before get_page(); calling it
+    # on a document without a form is a no-op.
+    pdfium_doc.init_forms()
+
     pdfium_page = pdfium_doc.get_page(page_ix)
 
     img: PIL.Image.Image = pdfium_page.render(


### PR DESCRIPTION
## Summary

\`page.to_image()\` (which goes through \`pdfplumber.display.get_page_image\`) currently opens a \`pypdfium2.PdfDocument\` and loads the page **without initializing PDFium's form environment**. Filled AcroForm field text is rendered via PDFium's form-rendering layer (\`FPDF_FFLDraw\`), which only runs when a form environment exists. Result: filled form-field text is **missing from the PIL bitmap**, even though every standard PDF viewer shows it.

This is purely a PDFium rasterization gap — pdfminer text extraction (\`page.chars\`, \`extract_text()\`) is unaffected.

## Reproduction

```python
import pdfplumber

with pdfplumber.open(\"filled_form.pdf\") as pdf:
    im = pdf.pages[0].to_image(resolution=150).original
    im.save(\"out.png\")  # filled field values absent
```

(Reproducer + sample PDF in #1367.)

## Fix

One-line addition in \`pdfplumber/display.py::get_page_image\`:

```python
pdfium_doc = pypdfium2.PdfDocument(src, password=password)
...
pdfium_doc.init_forms()  # <-- new
pdfium_page = pdfium_doc.get_page(page_ix)
```

Per [pypdfium2's documentation](https://pypdfium2.readthedocs.io/), \`init_forms()\` must be called **after** open and **before** loading pages. On a document without a form it is a no-op, so this is safe for the common non-form case.

## Test plan

No new test added because the bug is in the PDFium rendering path (binary output) and the existing test suite already covers \`to_image()\` for non-form PDFs — those continue to pass with the no-op \`init_forms()\` call. For form PDFs the existing tests cannot detect the regression visually; the rasterized bitmap differs only in a few hundred pixels per filled field.

Happy to add a pixel-comparison or perceptual-hash test against the sample PDF in #1367 if maintainers want — let me know.

## CHANGELOG

Added under \`## Unreleased\`.

Closes #1367.