### PR TITLE
docs: fix missing "from" in line object y1 description

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ my_char_rotation = my_char_ctm.skew_x
 |`x0`| Distance of left-side extremity from left side of page.|
 |`x1`| Distance of right-side extremity from left side of page.|
 |`y0`| Distance of bottom extremity from bottom of page.|
-|`y1`| Distance of top extremity bottom of page.|
+|`y1`| Distance of top extremity from bottom of page.|
 |`top`| Distance of top of line from top of page.|
 |`bottom`| Distance of bottom of the line from top of page.|
 |`doctop`| Distance of top of line from top of document.|


### PR DESCRIPTION
## Summary

The \`line\` properties table in README.md describes \`y1\` as:

\`\`\`
| \`y1\` | Distance of top extremity bottom of page. |
\`\`\`

The word \"from\" is missing. The parallel entries for \`char\`, \`rect\`, \`curve\`, and \`image\` all use the \"Distance of top of X **from** bottom of page\" wording.

## Fix

Adds the missing preposition. One-line diff. Surfaces while reviewing #1369 (separate substantive issue about pdfplumber's y-coordinate conventions, not in scope for this PR).