### PR TITLE
Update Pillow dependency to address security concerns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file. The format 
 ## Unreleased
 
 - Upgrade `pdfminer.six` from `20251230` to `20260107`. ([07a5ff6](https://github.com/jsvine/pdfplumber/commit/07a5ff6))
-
+- Upgrade the minimum `Pillow` dependency version from `9.1` to `12.2.0`.
+- 
 ## 0.11.9 — 2026-01-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -574,6 +574,7 @@ Many thanks to the following users who've contributed ideas, features, and fixes
 - [Brandon Roberts](https://github.com/brandonrobertz)
 - [@ennamarie19](https://github.com/ennamarie19)
 - [Anton Ilin](https://github.com/bronislav)
+- [Joe Tang](https://github.com/tkjoetang)
 
 ## Contributing
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pdfminer.six==20260107
-Pillow>=9.1
+Pillow>=12.2.0
 pypdfium2>=4.18.0


### PR DESCRIPTION
This PR updates the minimum Pillow dependency from 9.1 to 12.2.0.

The change was motivated by security concerns raised during an internal dependency review. Older Pillow versions may be flagged by security scanners due to known vulnerabilities.

## Changes

* Updated Pillow dependency requirement
* Updated CHANGELOG.md
* Added myself to the contributors list

## Testing

Ran:

```bash
python -m pytest
```

Most tests passed locally. The Ghostscript-related tests in `tests/test_repair.py` were not validated because Ghostscript is not installed on my work machine.