### PR TITLE
Initialize PDFium's form environment so filled AcroForm fields render in to_image()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## [Unreleased]
+
+### Fixed
+- Initialize PDFium's form environment in `get_page_image` so that filled AcroForm field content is included when rendering pages via `Page.to_image()`. ([#1367](https://github.com/jsvine/pdfplumber/issues/1367))
+
 ## [0.11.10] — 2026-06-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -574,6 +574,7 @@ Many thanks to the following users who've contributed ideas, features, and fixes
 - [Brandon Roberts](https://github.com/brandonrobertz)
 - [@ennamarie19](https://github.com/ennamarie19)
 - [Anton Ilin](https://github.com/bronislav)
+- [Sebastian Cao](https://github.com/cycsmail)
 
 ## Contributing
 

--- a/pdfplumber/display.py
+++ b/pdfplumber/display.py
@@ -58,6 +58,12 @@ def get_page_image(
     except pypdfium2.PdfiumError as e:
         raise MalformedPDFException(e)
 
+    # Initialize the form environment so that filled AcroForm field
+    # content is drawn into the rendered bitmap. Must be called after
+    # opening the document and before loading any pages.
+    # See https://github.com/jsvine/pdfplumber/issues/1367
+    pdfium_doc.init_forms()
+
     pdfium_page = pdfium_doc.get_page(page_ix)
 
     img: PIL.Image.Image = pdfium_page.render(

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -125,6 +125,20 @@ class Test(unittest.TestCase):
         with pdfplumber.open(path, password="test") as pdf:
             pdf.pages[0].to_image()
 
+    def test_acroform_widgets_rendered(self):
+        # See https://github.com/jsvine/pdfplumber/issues/1367
+        # Filled AcroForm field content should be drawn into the rendered
+        # bitmap, which requires PDFium's form environment to be initialized.
+        path = os.path.join(HERE, "pdfs/federal-register-2020-17221.pdf")
+        with pdfplumber.open(path) as pdf:
+            im = pdf.pages[0].to_image(resolution=150)
+        # This region contains a filled form field that is blank unless the
+        # form environment is initialized before rendering.
+        region = im.original.crop((88, 26, 171, 67))
+        colors = region.getcolors(maxcolors=region.size[0] * region.size[1])
+        non_white = sum(count for count, color in colors if color != (255, 255, 255))
+        assert non_white > 0
+
     def test_zip(self):
         # See https://github.com/jsvine/pdfplumber/issues/948
         # reproducer.py


### PR DESCRIPTION
Fixes #1367.

`get_page_image` opens the PDFium document but never calls `init_forms()`, so any filled AcroForm widget content is missing from the bitmap that `Page.to_image()` produces. Adding the call right after the document is opened (and before the page is loaded) fixes it; it's a no-op for PDFs that have no form, so non-form rendering is unchanged.

Added a regression test reusing the existing `federal-register-2020-17221.pdf` fixture: it renders page 0 and asserts that a crop over a filled form field has non-white pixels. Without the fix that region is blank (0 non-white pixels) and the test fails; with it the region has content (945) and it passes. The `tests/test_display.py` suite passes (17 tests) and black/isort/flake8 are clean.
