### PR TITLE
Fix bytes serializer dropping non-UTF-8 values to null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Fixed
 - Initialize PDFium's form environment in `get_page_image` so that filled AcroForm field content is included when rendering pages via `Page.to_image()`. ([#1367](https://github.com/jsvine/pdfplumber/issues/1367))
 - Include the wrapped exception's class name in `PdfminerException`'s message when `pdfminer.six` raises an exception without one (e.g. `PDFPasswordIncorrect`), which previously surfaced as a blank error message.
+- Fix `Serializer.do_bytes` to continue to the next entry in `ENCODINGS_TO_TRY` instead of returning `None` on the first failed encoding, so non-UTF-8 `bytes` attributes (e.g. an annotation's `Contents`) are no longer dropped to `null` by `.to_json()`/`.to_csv()`/`.to_dict()`.
 
 ## [0.11.10] — 2026-06-14
 
@@ -688,4 +689,3 @@ Whoops.
 
 ### Fixed
 - Fix find_gutters — should ignore `" "` chars
-

--- a/pdfplumber/convert.py
+++ b/pdfplumber/convert.py
@@ -119,8 +119,8 @@ class Serializer:
         for e in ENCODINGS_TO_TRY:
             try:
                 return obj.decode(e)
-            except UnicodeDecodeError:  # pragma: no cover
-                return None
+            except UnicodeDecodeError:
+                continue
         # If none of the decodings work, raise whatever error
         # decoding with utf-8 causes
         obj.decode(ENCODINGS_TO_TRY[0])  # pragma: no cover

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -173,6 +173,42 @@ class Test(unittest.TestCase):
             c = json.loads(pdf.to_json())
             assert len(c["pages"][0]["images"])
 
+    def test_serialize_bytes_encoding_fallback(self):
+        # Serializer.do_bytes must try each entry in ENCODINGS_TO_TRY until one
+        # decodes, instead of returning None on the first failure. latin-1 (the
+        # second entry) decodes any byte string, so no bytes value is ever lost
+        # to None. Regression test for the broken encoding-fallback loop.
+        from pdfplumber.convert import ENCODINGS_TO_TRY, Serializer
+
+        assert ENCODINGS_TO_TRY[0] == "utf-8"
+        assert "latin-1" in ENCODINGS_TO_TRY
+        serialize = Serializer().serialize
+        # Valid utf-8 (including ascii) still passes through unchanged.
+        assert serialize(b"plain ascii") == "plain ascii"
+        assert serialize("café".encode("utf-8")) == "café"
+        # Bytes that are not valid utf-8 fall back to latin-1 rather than None.
+        assert serialize(b"caf\xe9") == "café"
+        for raw in (b"\xe9", b"\x80\x81", b"\xff\xfe\x00", b"\x91\x92\x93"):
+            decoded = serialize(raw)
+            assert decoded is not None
+            assert isinstance(decoded, str)
+            assert decoded == raw.decode("latin-1")
+
+    def test_json_non_utf8_bytes_preserved(self):
+        # The annotation in this shipped fixture carries a non-UTF-8 (UTF-16BE)
+        # Contents value. Both the top-level "contents" (decoded via page.py)
+        # and the serialized "data.Contents" (via Serializer.do_bytes) must
+        # survive to_json as strings instead of being dropped to null.
+        path = os.path.join(HERE, "pdfs/issue-463-example.pdf")
+        with pdfplumber.open(path) as pdf:
+            annot = json.loads(pdf.to_json(object_types=["annot"]))["pages"][0][
+                "annots"
+            ][0]
+        assert annot["contents"] is not None
+        data_contents = annot["data"]["Contents"]
+        assert data_contents is not None
+        assert isinstance(data_contents, str)
+
     def test_csv(self):
         c = self.pdf.to_csv(precision=3)
         assert c.split("\r\n")[9] == (


### PR DESCRIPTION
### The bug

`Serializer.do_bytes` serializes any non-UTF-8 `bytes` attribute to `null`, so values silently disappear from `to_json` / `to_csv` / `to_dict` output:

```python
from pdfplumber.convert import Serializer, ENCODINGS_TO_TRY
print(ENCODINGS_TO_TRY)                    # ['utf-8', 'latin-1', 'utf-16', 'utf-16le']
print(Serializer().serialize(b"caf\xe9"))  # -> None   (expected 'café')
```

End-to-end, on the shipped `tests/pdfs/issue-463-example.pdf` (an annotation whose `Contents` is UTF-16BE):

```python
import json, pdfplumber
pdf = pdfplumber.open("tests/pdfs/issue-463-example.pdf")
a = json.loads(pdf.to_json(object_types=["annot"]))["pages"][0]["annots"][0]
print(a["contents"], "|", a["data"]["Contents"])   # '日本語' | None   <- data loss
```

### Root cause

```python
def do_bytes(self, obj: bytes) -> Optional[str]:
    for e in ENCODINGS_TO_TRY:
        try:
            return obj.decode(e)
        except UnicodeDecodeError:  # pragma: no cover
            return None             # <-- aborts the loop on the first failure
```

The `except` returns `None` on the *first* encoding that fails, so the `latin-1` / `utf-16` / `utf-16le` fallbacks never run. `git blame` shows the type-annotation refactor in `9587cc7` changed the original `pass` (continue the loop) to `return None`. Because `latin-1` decodes any byte string, the intended loop never returns `None` and never reaches the trailing re-raise — both of which became dead code (the `# pragma: no cover` even encodes the now-false assumption that the `except` never fires).

### The fix

Restore the loop: `continue` to the next encoding instead of returning `None` (and drop the now-reachable `# pragma: no cover`). One line; the trailing re-raise is left untouched.

I deliberately do **not** change the encoding *order* — `latin-1` precedes `utf-16`, so a UTF-16 value comes back as latin-1 text rather than its "ideal" decoding. That ordering is a separate, pre-existing design choice; restoring the loop exactly matches the original behaviour and fixes the data loss without scope creep.

### Tests (`tests/test_convert.py`)

- `test_serialize_bytes_encoding_fallback` pins the contract: `utf-8` passthrough is unchanged, and each of several non-UTF-8 byte strings serializes to its `latin-1` string rather than `None`.
- `test_json_non_utf8_bytes_preserved` exercises the public `to_json` API on the shipped `issue-463-example.pdf` fixture, asserting both the top-level `contents` and the serialized `data.Contents` survive as strings.

Both fail on the current code with the value dropped to `None`/`null` and pass with the fix; `tests/test_convert.py` + `tests/test_basics.py` stay green (39 passed); `black`/`isort`/`flake8` clean. CHANGELOG updated.
