### PR TITLE
Handle inline (non-reference) structure elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Fixed
 - Initialize PDFium's form environment in `get_page_image` so that filled AcroForm field content is included when rendering pages via `Page.to_image()`. ([#1367](https://github.com/jsvine/pdfplumber/issues/1367))
 - Include the wrapped exception's class name in `PdfminerException`'s message when `pdfminer.six` raises an exception without one (e.g. `PDFPasswordIncorrect`), which previously surfaced as a blank error message.
+- Handle structure elements embedded inline (as direct dictionaries) in another element's `/K`, rather than only as indirect references. Such elements are permitted by the PDF spec but previously caused `structure_tree` to raise a `KeyError`.
 
 ## [0.11.10] — 2026-06-14
 
@@ -688,4 +689,3 @@ Whoops.
 
 ### Fixed
 - Fix find_gutters — should ignore `" "` chars
-

--- a/pdfplumber/structure.py
+++ b/pdfplumber/structure.py
@@ -383,7 +383,9 @@ class PDFStructTree(Findable):
                         child = obj["Obj"]
                     elif "MCID" in obj:
                         continue
-                if isinstance(child, PDFObjRef):
+                # A child may be an indirect reference or, per the spec, a
+                # structure element dictionary embedded directly in /K.
+                if isinstance(child, (PDFObjRef, dict)):
                     d.append(child)
 
         # Traverse depth-first, removing empty elements (unsure how to
@@ -452,8 +454,10 @@ class PDFStructTree(Findable):
                         element.mcids.append(obj["MCID"])
                     elif "Obj" in obj:
                         child = obj["Obj"]
-                # NOTE: if, not elif, in case of OBJR above
-                if isinstance(child, PDFObjRef):
+                # NOTE: if, not elif, in case of OBJR above. An inline child is
+                # a structure element dictionary embedded directly in /K (MCID
+                # dicts were already handled above and are not in `seen`).
+                if isinstance(child, (PDFObjRef, dict)):
                     child_element, _ = seen.get(repr(child), (None, None))
                     if child_element is not None:
                         element.children.append(child_element)

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import io
 import os
 import re
 import unittest
@@ -1073,3 +1074,64 @@ class TestMany(unittest.TestCase):
             assert pdf.pages[0].structure_tree == HELLO1P
         with pdfplumber.open(path, pages=[1]) as pdf:
             assert pdf.structure_tree == HELLO1
+
+
+def _build_inline_struct_pdf():
+    """A minimal tagged PDF whose Document structure element holds an inline
+    (direct dictionary) P structure element in its /K array, rather than an
+    indirect reference. Inline structure elements are permitted by PDF 1.7
+    section 14.7.2."""
+    objs = {
+        1: (
+            b"<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 5 0 R "
+            b"/MarkInfo << /Marked true >> >>"
+        ),
+        2: b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        3: (
+            b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] "
+            b"/Contents 4 0 R /Resources << /Font << /F1 7 0 R >> >> "
+            b"/StructParents 0 >>"
+        ),
+        5: b"<< /Type /StructTreeRoot /K 6 0 R >>",
+        6: (
+            b"<< /Type /StructElem /S /Document /K "
+            b"[ << /Type /StructElem /S /P /Pg 3 0 R /K 0 >> ] >>"
+        ),
+        7: b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    }
+    content = b"/P << /MCID 0 >> BDC BT /F1 12 Tf 50 100 Td (Hi) Tj ET EMC"
+    objs[4] = b"<< /Length %d >>\nstream\n%s\nendstream" % (len(content), content)
+
+    out = bytearray(b"%PDF-1.7\n")
+    offsets = {}
+    for i in sorted(objs):
+        offsets[i] = len(out)
+        out += b"%d 0 obj\n" % i + objs[i] + b"\nendobj\n"
+    xref_pos = len(out)
+    n = len(objs) + 1
+    out += b"xref\n0 %d\n0000000000 65535 f \n" % n
+    for i in sorted(objs):
+        out += b"%010d 00000 n \n" % offsets[i]
+    out += b"trailer\n<< /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n" % (
+        n,
+        xref_pos,
+    )
+    return bytes(out)
+
+
+class TestInlineStructureElement(unittest.TestCase):
+    """A structure element embedded inline (a direct dictionary, not an
+    indirect reference) in another element's /K must parse rather than raise
+    KeyError. See PDF 1.7 section 14.7.2."""
+
+    def test_inline_structure_element(self):
+        with pdfplumber.open(io.BytesIO(_build_inline_struct_pdf())) as pdf:
+            assert pdf.structure_tree == [
+                {
+                    "type": "Document",
+                    "children": [{"type": "P", "page_number": 1, "mcids": [0]}],
+                }
+            ]
+            assert pdf.pages[0].structure_tree == [
+                {"type": "Document", "children": [{"type": "P", "mcids": [0]}]}
+            ]


### PR DESCRIPTION
### The bug

`PDF.structure_tree` / `Page.structure_tree` raise `KeyError` when a structure element is embedded **inline** — as a direct dictionary in another element's `/K` — rather than as an indirect reference:

```
File ".../pdfplumber/structure.py", line 407, in prune
    children = prune(children)
File ".../pdfplumber/structure.py", line 406, in prune
    element, children = s[repr(ref)]
KeyError: "{'Type': /'StructElem', 'S': /'P', 'Pg': <PDFObjRef:3>, 'K': 0}"
```

Per PDF 1.7 §14.7.2, the `/K` value "may be ... a structure element dictionary ... or an array of such". `_make_element` already has an explicit branch for an inline-dict child (`# a single object.. ugh...`), and `_parse_struct_tree` / `_resolve_children` already handle an inline dict at the *root* — but the per-child traversal does not, so a nested inline element crashes.

### Root cause

In `_parse_struct_tree`'s main loop, only `PDFObjRef` children are pushed onto the work queue (and thus registered in the `s` lookup). An inline structure-element dict is silently skipped, so it never gets an `s` entry — and `prune()` then hits `s[repr(ref)]` → `KeyError`. `_resolve_children` follows the same `PDFObjRef`-only rule, so even past the crash an inline child would be dropped from the output.

### The fix

Two symmetric one-line changes: in both the traversal loop and `_resolve_children`, treat a child that is a structure-element *dictionary* the same as an indirect reference (`isinstance(child, (PDFObjRef, dict))`). MCID dicts were already handled/`continue`d earlier and are not in the lookup, so they're unaffected; `prune()` needs no change once inline elements are registered.

### Tests

`test_inline_structure_element` builds a minimal tagged PDF in memory whose `Document` element holds an inline `P` element in its `/K` array, and asserts the parsed tree on both the document-level (`pdf.structure_tree`) and page-level (`page.structure_tree`) code paths. It fails on `develop` with the exact `KeyError` and passes with the fix; `tests/test_structure.py` + `tests/test_mcids.py` + `tests/test_basics.py` stay green (39 passed); `black`/`isort`/`flake8` clean. CHANGELOG updated.

(None of the 65 shipped test PDFs exercise inline structure children, so this path was previously untested.)
