### PR TITLE
Fix coordinate inversion when MediaBox origin is not (0, 0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Fixed
 - Initialize PDFium's form environment in `get_page_image` so that filled AcroForm field content is included when rendering pages via `Page.to_image()`. ([#1367](https://github.com/jsvine/pdfplumber/issues/1367))
 - Include the wrapped exception's class name in `PdfminerException`'s message when `pdfminer.six` raises an exception without one (e.g. `PDFPasswordIncorrect`), which previously surfaced as a blank error message.
+- Subtract the `MediaBox` origin when inverting coordinates, so that pages whose `MediaBox` does not begin at `y == 0` are no longer shifted vertically (previously producing negative `top` values). ([#1332](https://github.com/jsvine/pdfplumber/issues/1332))
 
 ## [0.11.10] — 2026-06-14
 
@@ -688,4 +689,3 @@ Whoops.
 
 ### Fixed
 - Fix find_gutters — should ignore `" "` chars
-

--- a/README.md
+++ b/README.md
@@ -577,6 +577,7 @@ Many thanks to the following users who've contributed ideas, features, and fixes
 - [Sebastian Cao](https://github.com/cycsmail)
 - [Kaspar Naraghi](https://github.com/kaninaba94)
 - [Siddharth Gaur](https://github.com/siddharthgaur1)
+- [Apoorv Darshan](https://github.com/apoorvdarshan)
 
 ## Contributing
 

--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -177,10 +177,15 @@ def _normalize_box(box_raw: T_bbox, rotation: T_num = 0) -> T_bbox:
 
 # PDFs coordinate spaces refer to an origin in the bottom-left of the
 # page; pdfplumber flips this vertically, so that the origin is in the
-# top-left.
-def _invert_box(box_raw: T_bbox, mb_height: T_num) -> T_bbox:
+# top-left. The flip is performed about the MediaBox's top edge
+# (`mb_top_edge`, i.e. the raw upper-`y` coordinate) rather than about
+# the MediaBox height, so that the origin is subtracted correctly even
+# when the MediaBox does not start at `y == 0` (see issue #1332). For a
+# MediaBox whose lower-left is `(0, 0)`, `mb_top_edge` equals the height,
+# so this leaves the common case unchanged.
+def _invert_box(box_raw: T_bbox, mb_top_edge: T_num) -> T_bbox:
     x0, y0, x1, y1 = box_raw
-    return (x0, mb_height - y1, x1, mb_height - y0)
+    return (x0, mb_top_edge - y1, x1, mb_top_edge - y0)
 
 
 class Page(Container):
@@ -212,14 +217,17 @@ class Page(Container):
         self.rotation = _rotation % 360
 
         mb_raw = _normalize_box(get_attr("MediaBox"), self.rotation)
-        mb_height = mb_raw[3] - mb_raw[1]
+        # The raw upper-`y` coordinate; used as the axis for the vertical
+        # flip so that the MediaBox origin is subtracted even when the
+        # MediaBox does not begin at `y == 0` (see issue #1332).
+        mb_top_edge = mb_raw[3]
 
-        self.mediabox = _invert_box(mb_raw, mb_height)
+        self.mediabox = _invert_box(mb_raw, mb_top_edge)
 
         for box_name in ["CropBox", "TrimBox", "BleedBox", "ArtBox"]:
             if box_name in page_obj.attrs:
                 box_normalized = _invert_box(
-                    _normalize_box(get_attr(box_name), self.rotation), mb_height
+                    _normalize_box(get_attr(box_name), self.rotation), mb_top_edge
                 )
                 setattr(self, box_name.lower(), box_normalized)
 

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -316,6 +316,38 @@ class Test(unittest.TestCase):
                 ["", "", ""],
             ]
 
+    def test_issue_1332(self):
+        """
+        The vertical flip must subtract the MediaBox origin, so that pages
+        whose MediaBox does not begin at `y == 0` are not shifted vertically.
+
+        `issue-1181.pdf`'s first page has a MediaBox of
+        `[0, 200, 420.9449, 585.2756]`. Before the fix, its origin's `y0`
+        (200) was not subtracted, so the page's `top` coordinates were
+        shifted by -200 (yielding negative `top` values) and its
+        `mediabox`/`bbox` began at `y == -200`.
+        """
+        path = os.path.join(HERE, "pdfs/issue-1181.pdf")
+        with pdfplumber.open(path) as pdf:
+            page = pdf.pages[0]
+
+            # The (inverted) MediaBox top edge should map to top == 0,
+            # regardless of the MediaBox's raw y-origin.
+            assert page.mediabox[1] == 0
+            assert page.bbox[1] == 0
+            assert page.mediabox[3] == pytest.approx(page.height)
+
+            # No on-page object should have a negative `top` (previously
+            # every object was shifted -200 into negative territory).
+            objs = page.rects + page.lines + page.chars
+            assert objs
+            assert min(obj["top"] for obj in objs) >= 0
+
+            # Spot-check a specific character's corrected coordinates.
+            first_char = page.chars[0]
+            assert first_char["top"] == pytest.approx(236.4637, abs=1e-3)
+            assert first_char["bottom"] == pytest.approx(244.4637, abs=1e-3)
+
     def test_pr_1195(self):
         """
         In certain scenarios, annotations may include invalid or extraneous


### PR DESCRIPTION
Fixes #1332.

### Root cause

`_invert_box` (in `pdfplumber/page.py`) flips PDF coordinates vertically so
the origin ends up in the top-left. It did so about the MediaBox **height**:

```python
def _invert_box(box_raw, mb_height):
    x0, y0, x1, y1 = box_raw
    return (x0, mb_height - y1, x1, mb_height - y0)
```

with `mb_height = mb_raw[3] - mb_raw[1]`. Because it subtracts from the
height rather than from the raw top edge (`mb_raw[3]`), the MediaBox's
raw y-origin (`mb_raw[1]`) is never subtracted. For a MediaBox whose
lower-left is `(0, 0)` this is fine (`mb_height == mb_raw[3]`), but when
the MediaBox does not begin at `y == 0` every `top`/`bottom` is shifted by
that origin, and `page.mediabox` / `page.bbox` start at a non-zero `y`.
(pdfminer.six already normalizes object coordinates to a `(0, 0)`-origin
page, so the flip must not re-introduce the origin.)

### Reproduction

A PDF with a centered-origin MediaBox `[-100 -200 100 200]` containing a
single rectangle drawn at raw coordinates `10 20 30 40 re` (raw span
`x: 10..40`, `y: 20..60`):

```python
import pdfplumber
with pdfplumber.open("centered.pdf") as pdf:
    p = pdf.pages[0]
    print("mediabox:", p.mediabox)
    r = p.rects[0]
    print("rect top/bottom:", r["top"], r["bottom"])
```

**Actual (before):**

```
mediabox: (-100, 200, 100, 600)
rect top/bottom: 340.0 380.0
```

The page's top edge sits at `top == 200` and `mediabox[3] == 600` even
though the page is only `400` units tall — the whole page is shifted down
by the origin (`200`).

**Corrected (after):**

```
mediabox: (-100, 0, 100, 400)
rect top/bottom: 140.0 180.0
```

`top` now ranges over `[0, height]`, as expected.

This also matches the report in #1332: raw MediaBox `(-100, -200, 100, 200)`
previously yielded `(-100, 200, 100, 600)`.

The regression is also visible on the existing `tests/pdfs/issue-1181.pdf`
fixture, whose first page has MediaBox `[0, 200, 420.9449, 585.2756]`:

- Before: `page.mediabox == (0, -200.0, 420.9449, 185.2756)`, and object
  `top` values were shifted `-200` into negative territory
  (`min(top) == -41.3`).
- After: `page.mediabox == (0, 0.0, 420.9449, 385.2756)`, and `min(top)`
  is `158.7` (all non-negative).

### Fix

Flip about the raw upper-`y` edge (`mb_raw[3]`) instead of the height.
This subtracts the origin correctly and is a no-op for the common case
(where the MediaBox lower-left is `(0, 0)`, so the top edge equals the
height). The change is confined to the two MediaBox/CropBox call sites in
`Page.__init__`; the x-offset behavior introduced for #1181 is preserved
(object x-coordinates and `page.mediabox[0]` still keep the raw
MediaBox `x0`), and downstream consumers (`process_object`,
`point2coord`) read the corrected origin from `self.mediabox`
automatically, so no other code needed to change.

### Tests

Added `tests/test_issues.py::test_issue_1332`, which uses the existing
`issue-1181.pdf` fixture (its first page has a non-zero MediaBox
y-origin) and asserts that the inverted MediaBox begins at `y == 0`, that
no object has a negative `top`, and that a sample character's coordinates
are corrected. The test fails on the current code
(`assert -200.0 == 0`) and passes with the fix. The existing suite
continues to pass (`python -m pytest`, excluding the `test_repair.py`
cases that require a local Ghostscript install, which is unrelated to this
change). `black`, `isort`, and `flake8` are clean on the changed files.

Disclosure: prepared with AI assistance; reviewed and verified locally.
