### PR TITLE
fix: keep y0/y1 in sync when clipping objects in clip_obj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 ## [Unreleased]
 
 ### Fixed
+- Update an object's `y0`/`y1` coordinates when it is clipped by `.crop(...)` / `.within_bbox(...)` / `.outside_bbox(...)`, so that they stay consistent with the object's `top`/`bottom`/`height`. Previously `clip_obj` updated only the top-based coordinates, leaving `y0`/`y1` stale for vertically-clipped objects.
 - Initialize PDFium's form environment in `get_page_image` so that filled AcroForm field content is included when rendering pages via `Page.to_image()`. ([#1367](https://github.com/jsvine/pdfplumber/issues/1367))
 
 ## [0.11.10] — 2026-06-14

--- a/README.md
+++ b/README.md
@@ -575,6 +575,7 @@ Many thanks to the following users who've contributed ideas, features, and fixes
 - [@ennamarie19](https://github.com/ennamarie19)
 - [Anton Ilin](https://github.com/bronislav)
 - [Sebastian Cao](https://github.com/cycsmail)
+- [@Otis0408](https://github.com/Otis0408)
 
 ## Contributing
 

--- a/pdfplumber/utils/geometry.py
+++ b/pdfplumber/utils/geometry.py
@@ -87,6 +87,10 @@ def clip_obj(obj: T_obj, bbox: T_bbox) -> Optional[T_obj]:
     diff = dims["top"] - obj["top"]
     if "doctop" in copy:
         copy["doctop"] = obj["doctop"] + diff
+    if "y1" in copy:
+        copy["y1"] = obj["y1"] - diff
+    if "y0" in copy:
+        copy["y0"] = obj["y0"] - (dims["bottom"] - obj["bottom"])
     copy["width"] = copy["x1"] - copy["x0"]
     copy["height"] = copy["bottom"] - copy["top"]
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -146,6 +146,27 @@ class Test(unittest.TestCase):
         )
         assert len(crop_right_again_rel.chars)
 
+    def test_crop_preserves_y0_y1(self):
+        # Cropping vertically clips an object's top/bottom edges; the
+        # PDF-space y0/y1 coordinates must stay in sync so that the
+        # top/bottom <-> y0/y1 invariant still holds. Previously clip_obj
+        # updated top/bottom (and height) but left y0/y1 stale.
+        page = self.pdf_2.pages[0]
+        height = page.height
+        c = page.chars[0]
+        # Crop through the vertical middle of the first char, so it is
+        # clipped along its top edge.
+        bbox = (c["x0"] - 1, (c["top"] + c["bottom"]) / 2, c["x1"] + 1, c["bottom"] + 5)
+        cropped = page.crop(bbox)
+        clipped = [ch for ch in cropped.chars if "y0" in ch and "y1" in ch]
+        assert len(clipped)
+        # At least one char must actually have been shortened by the crop.
+        assert any(ch["height"] < c["height"] for ch in clipped)
+        for ch in clipped:
+            assert ch["y1"] - ch["y0"] == pytest.approx(ch["height"])
+            assert ch["top"] == pytest.approx(height - ch["y1"])
+            assert ch["bottom"] == pytest.approx(height - ch["y0"])
+
     def test_invalid_crops(self):
         page = self.pdf.pages[0]
         with pytest.raises(ValueError):


### PR DESCRIPTION
### Who hits this

Anyone reading `y0`/`y1` off an object that was clipped by `.crop(...)`, `.within_bbox(...)`, or `.outside_bbox(...)`. Those fields are part of the public per-object schema (exported via `to_dict`, `.objects`, and the CSV/JSON output, documented as "distance from bottom of page"), so consumers that read `y0`/`y1` — or compute geometry/height from them — on a cropped page get silently wrong numbers. Text extraction is unaffected (it uses `top`/`doctop`/`x0`), so this is silent corruption of the coordinate fields rather than a crash.

### Root cause

`clip_obj` in `pdfplumber/utils/geometry.py` rewrites an object's top-based coordinates (`x0`, `x1`, `top`, `bottom`, `doctop`, `width`, `height`) but never updates the PDF-space `y0`/`y1`. pdfplumber objects carry the same box in two coordinate systems with the invariant `top == page_bottom_ref - y1` and `bottom == page_bottom_ref - y0`. After a vertical clip, `top`/`bottom` shift but `y0`/`y1` keep their pre-crop values, so the two representations describe different boxes and `y1 - y0` no longer equals `height`. The sibling helpers `move_object` and `resize_object` both already update `y0`/`y1` when present; only `clip_obj` was missing it.

### The fix

After computing the clipped `top`/`bottom`, also update `y0`/`y1` when present, mirroring `resize_object`: `y1` tracks `top`, `y0` tracks `bottom`.

```python
if "y1" in copy:
    copy["y1"] = obj["y1"] - diff
if "y0" in copy:
    copy["y0"] = obj["y0"] - (dims["bottom"] - obj["bottom"])
```

### Before / after

Cropping a page so `chars[0]` (top=117.18, bottom=135.18, y0=656.82, y1=674.82, height=18) is cut in half vertically:

- Before: `top=126.18`, `bottom=135.18`, `height=9.0`, but `y0=656.82`, `y1=674.82` -> `y1-y0 = 18.0` (stale); `page.height - y1 = 117.18` != `top`
- After: `y1=665.82`, `y0=656.82` -> `y1-y0 = 9.0 = height`, and `page.height - y1 = 126.18 = top`, `page.height - y0 = 135.18 = bottom`

### Notes

- Adds a regression test `test_crop_preserves_y0_y1` in `tests/test_basics.py` that crops through a char vertically and asserts `y1-y0 == height` and the `top`/`bottom` to `y0`/`y1` invariant. It fails on the current code and passes with this change.
- Updates `CHANGELOG.md` (Unreleased / Fixed) and adds a contributor entry to `README.md`.
- `make lint` passes (flake8, mypy, black, isort).
