### PR TITLE
Surface wrapped exception class name in blank PdfminerException messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Fixed
 - Initialize PDFium's form environment in `get_page_image` so that filled AcroForm field content is included when rendering pages via `Page.to_image()`. ([#1367](https://github.com/jsvine/pdfplumber/issues/1367))
+- Include the wrapped exception's class name in `PdfminerException`'s message when `pdfminer.six` raises an exception without one (e.g. `PDFPasswordIncorrect`), which previously surfaced as a blank error message.
 
 ## [0.11.10] — 2026-06-14
 

--- a/README.md
+++ b/README.md
@@ -576,6 +576,7 @@ Many thanks to the following users who've contributed ideas, features, and fixes
 - [Anton Ilin](https://github.com/bronislav)
 - [Sebastian Cao](https://github.com/cycsmail)
 - [Kaspar Naraghi](https://github.com/kaninaba94)
+- [Siddharth Gaur](https://github.com/siddharthgaur1)
 
 ## Contributing
 

--- a/pdfplumber/utils/exceptions.py
+++ b/pdfplumber/utils/exceptions.py
@@ -3,4 +3,11 @@ class MalformedPDFException(Exception):
 
 
 class PdfminerException(Exception):
-    pass
+    def __str__(self) -> str:
+        msg = super().__str__()
+        if not msg and self.args and isinstance(self.args[0], BaseException):
+            # pdfminer.six raises some exceptions without a message (e.g.
+            # PDFPasswordIncorrect), which would otherwise be surfaced here
+            # as a blank error message.
+            return type(self.args[0]).__name__
+        return msg

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -192,6 +192,14 @@ class Test(unittest.TestCase):
         with pdfplumber.open(path, password="test") as pdf:
             assert len(pdf.chars) > 0
 
+    def test_missing_password_message(self):
+        # pdfminer.six raises some exceptions without a message, which would
+        # otherwise be re-raised here as a blank PdfminerException.
+        path = os.path.join(HERE, "pdfs/password-example.pdf")
+        with pytest.raises(pdfplumber.utils.exceptions.PdfminerException) as exc:
+            pdfplumber.open(path)
+        assert "PDFPasswordIncorrect" in str(exc.value)
+
     def test_unicode_normalization(self):
         path = os.path.join(HERE, "pdfs/issue-905.pdf")
 


### PR DESCRIPTION
## Problem

`PdfminerException` can be raised with a completely empty message, giving no indication of what went wrong. The most common way to hit this is opening a password-protected PDF without supplying a password:

```python
import pdfplumber
pdfplumber.open("tests/pdfs/password-example.pdf")
```

```
pdfplumber.utils.exceptions.PdfminerException
```

That is the entire error — `str(e)` is `''`.

## Root cause

`pdfplumber` wraps pdfminer failures by passing the exception *instance*:

```python
except Exception as e:
    raise PdfminerException(e)
```

`str(Exception(inner))` delegates to `str(inner)`. `pdfminer.six` raises several exceptions bare — `PDFPasswordIncorrect` among them (`raise PDFPasswordIncorrect`, no arguments) — so `str(inner)` is `''` and the wrapper inherits the empty message.

This applies to all three wrap sites (`pdf.py:52`, `pdf.py:161`, `page.py:268`), so the fix is in the exception class rather than repeated at each `raise`.

## The fix

When the message would otherwise be empty and the wrapped argument is an exception, fall back to that exception's class name. The failing case now reports `PDFPasswordIncorrect`.

## Behaviour change

Limited to the message text of otherwise-blank exceptions.

- Exceptions that already carry a message are unaffected — verified byte-identical (e.g. `empty.pdf` still reports `No /Root object! - Is this really a PDF?`).
- The exception **type** is unchanged, so `pytest.raises(PdfminerException)` in `tests/test_basics.py` and the `ACCEPTABLE_EXCEPTIONS` tuple in `tests/test_oss_fuzz.py` behave as before.
- No existing test asserts on `PdfminerException`'s message text.

## Test

`tests/test_basics.py::Test::test_missing_password_message` opens the existing `password-example.pdf` fixture without a password and asserts the message is not blank. It fails on `develop` with `assert 'PDFPasswordIncorrect' in ''` and passes with this change. No new fixture required.

## Checks

All four lint/type gates from `.github/workflows/tests.yml` pass locally with the versions pinned in `requirements-dev.txt`: `black --check`, `isort --profile black --check-only`, `flake8`, and `mypy --strict --implicit-reexport`.

Test suite passes except for pre-existing environment-only failures on my machine (Ghostscript not installed for `test_repair.py`; CRLF line endings for `test_convert.py` on Windows) — none related to this change.

CHANGELOG and contributor list updated.

---

Happy to adjust the fallback format (e.g. `repr(inner)` instead of the class name) if you'd prefer something different.
