### PR TITLE
Document the `y0`/`y1` vs `top`/`bottom`/`doctop` coordinate systems in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Added
+- Add a "Coordinates" section to README.md, explaining the relationship between the `y0`/`y1` and `top`/`bottom`/`doctop` coordinate systems, why bounding boxes are expressed as `(x0, top, x1, bottom)`, and which objects carry which properties (h/t @soodoku). ([#389](https://github.com/jsvine/pdfplumber/issues/389))
+
 ### Fixed
 - Initialize PDFium's form environment in `get_page_image` so that filled AcroForm field content is included when rendering pages via `Page.to_image()`. ([#1367](https://github.com/jsvine/pdfplumber/issues/1367))
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,33 @@ Each instance of `pdfplumber.PDF` and `pdfplumber.Page` provides access to sever
 
 Each object is represented as a simple Python `dict`, with the following properties:
 
+#### Coordinates
+
+Horizontal coordinates are unambiguous: `x0` and `x1` are both measured from the left edge of the page. Vertical coordinates come in two varieties, and mixing them is a common source of confusion:
+
+| Property | Measured from | Direction |
+|----------|---------------|-----------|
+|`y0`, `y1`| Bottom of the page | Upward |
+|`top`, `bottom`| Top of the page | Downward |
+|`doctop`| Top of the *document* | Downward |
+
+The `y0`/`y1` pair follows the PDF specification's own coordinate system, and is retained for compatibility with `pdfminer.six`. Everything else in `pdfplumber` places the origin in the __top-left__ corner. In particular, bounding boxes are expressed as `(x0, top, x1, bottom)` — *not* `(x0, y0, x1, y1)` — which is what `.crop(...)`, `.within_bbox(...)`, and the visual-debugging methods expect.
+
+The top-left origin was chosen because ([#198](https://github.com/jsvine/pdfplumber/issues/198)) people generally read PDFs from the top-left toward the bottom-right; because measuring from the top is what makes `doctop` — the distance from the top of the *whole document* — able to distinguish objects at similar heights on different pages; and because most adjacent layout systems (SVG, Canvas, PIL/Pillow, which `pdfplumber` itself uses for visual debugging) also put the origin in the top-left.
+
+For a page whose `MediaBox` begins at the origin — the typical case — the two systems convert simply:
+
+```python
+y1 == page.height - top
+y0 == page.height - bottom
+```
+
+If the `MediaBox` does not begin at `(0, 0)`, both conversions are shifted by its vertical offset, `page.mediabox[1]`.
+
+Not every object carries both varieties. Objects parsed directly from the PDF — `char`, `line`, `rect`, `curve`, `image`, `annot`, and `hyperlink` — have all of the properties above. Objects that `pdfplumber` computes for you use only the top-down properties: the dicts returned by `.extract_words(...)` provide `top`, `bottom`, and `doctop` but no `y0`/`y1`, and those returned by `.search(...)` provide `top` and `bottom`. Relatedly, a `line`'s or `curve`'s `pts` are `(x, top)` tuples.
+
+Because object bounding boxes are normalized, `top` is never greater than `bottom`, and `height` (equal to `bottom - top`) is never negative.
+
 #### `char` properties
 
 | Property | Description |
@@ -576,6 +603,7 @@ Many thanks to the following users who've contributed ideas, features, and fixes
 - [Anton Ilin](https://github.com/bronislav)
 - [Sebastian Cao](https://github.com/cycsmail)
 - [Kaspar Naraghi](https://github.com/kaninaba94)
+- [Gaurav Sood](https://github.com/soodoku)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -156,20 +156,18 @@ Horizontal coordinates are unambiguous: `x0` and `x1` are both measured from the
 
 The `y0`/`y1` pair follows the PDF specification's own coordinate system, and is retained for compatibility with `pdfminer.six`. Everything else in `pdfplumber` places the origin in the __top-left__ corner. In particular, bounding boxes are expressed as `(x0, top, x1, bottom)` — *not* `(x0, y0, x1, y1)` — which is what `.crop(...)`, `.within_bbox(...)`, and the visual-debugging methods expect.
 
-The top-left origin was chosen because ([#198](https://github.com/jsvine/pdfplumber/issues/198)) people generally read PDFs from the top-left toward the bottom-right; because measuring from the top is what makes `doctop` — the distance from the top of the *whole document* — able to distinguish objects at similar heights on different pages; and because most adjacent layout systems (SVG, Canvas, PIL/Pillow, which `pdfplumber` itself uses for visual debugging) also put the origin in the top-left.
+The top-left origin was chosen because ([#198](https://github.com/jsvine/pdfplumber/issues/198)) people generally read PDFs from the top-left toward the bottom-right, and because most adjacent layout systems (SVG, Canvas, PIL/Pillow, which `pdfplumber` itself uses for visual debugging) also put the origin in the top-left.
 
 For a page whose `MediaBox` begins at the origin — the typical case — the two systems convert simply:
 
 ```python
-y1 == page.height - top
-y0 == page.height - bottom
+top == page.height - y1
+bottom == page.height - y0
 ```
 
 If the `MediaBox` does not begin at `(0, 0)`, both conversions are shifted by its vertical offset, `page.mediabox[1]`.
 
 Not every object carries both varieties. Objects parsed directly from the PDF — `char`, `line`, `rect`, `curve`, `image`, `annot`, and `hyperlink` — have all of the properties above. Objects that `pdfplumber` computes for you use only the top-down properties: the dicts returned by `.extract_words(...)` provide `top`, `bottom`, and `doctop` but no `y0`/`y1`, and those returned by `.search(...)` provide `top` and `bottom`. Relatedly, a `line`'s or `curve`'s `pts` are `(x, top)` tuples.
-
-Because object bounding boxes are normalized, `top` is never greater than `bottom`, and `height` (equal to `bottom - top`) is never negative.
 
 #### `char` properties
 


### PR DESCRIPTION
Closes #389.

Adds a `#### Coordinates` section to the README, directly above the per-object property tables, explaining the two vertical coordinate systems and how they relate.

The README currently defines `y0`/`y1`/`top`/`bottom`/`doctop` five separate times — once per object type — but never explains why there are two systems, which one bounding boxes use, or how to convert between them. That gap keeps generating issues: #198, #845, #1332, and as recently as this April, #1369, where a user reported as a bug that "y-coordinates are top-to-bottom for words but bottom-to-top for line points."

The section covers:

- which properties are measured from the page bottom (`y0`/`y1`) versus the page top (`top`/`bottom`) and the document top (`doctop`);
- that bounding boxes are `(x0, top, x1, bottom)`, not `(x0, y0, x1, y1)`, and that this is what `.crop(...)` / `.within_bbox(...)` expect;
- why the top-left origin was chosen, summarized from your answer in #198;
- the conversion `top == page.height - y1`, with the caveat that a non-zero `MediaBox` origin shifts it by `page.mediabox[1]`;
- that objects parsed from the PDF carry both varieties, while `.extract_words(...)` and `.search(...)` results carry only the top-down ones, and that `pts` are `(x, top)` tuples.

Every factual claim was checked against the library rather than against the existing prose:

- `top == page.height - y1` and `bottom == page.height - y0` hold exactly on a standard page, and fail by exactly `page.mediabox[1]` on `tests/pdfs/issue-1181.pdf` (`MediaBox` origin at `y = -200`), which is what the caveat records.
- The property inventory was confirmed by inspecting real objects: `char`/`line`/`rect`/`curve`/`image`/`annot`/`hyperlink` carry all seven; `.extract_words(...)` returns `top`/`bottom`/`doctop` and no `y0`/`y1`; `.search(...)` returns `top`/`bottom`.
- Using the reproduction attached to #1369, the documented rule accounts for the reported numbers exactly: read consistently in the top-down system, the two words land within 4 points of the line's endpoints, which is the agreement the reporter expected.

Docs-only, so no tests are added. `make lint` and `make tests` both pass locally (172 passed).
