### PR TITLE
Fix `make venv` creating the virtual environment at the wrong path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Fixed
 - Initialize PDFium's form environment in `get_page_image` so that filled AcroForm field content is included when rendering pages via `Page.to_image()`. ([#1367](https://github.com/jsvine/pdfplumber/issues/1367))
+- Fix `make venv`, which created the virtual environment at `venv/` but then installed into `${VENV}` (default `.venv/`), causing the target to fail on a fresh checkout (h/t @soodoku). ([ec96f72](https://github.com/jsvine/pdfplumber/commit/ec96f72))
 
 ## [0.11.10] — 2026-06-14
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VENV ?= .venv
 PYTHON = ${VENV}/bin/python
 
 venv:
-	python3 -m venv venv
+	python3 -m venv ${VENV}
 	${VENV}/bin/pip install --upgrade pip
 	${VENV}/bin/pip install -r requirements.txt
 	${VENV}/bin/pip install -r requirements-dev.txt


### PR DESCRIPTION
`make venv` currently fails on a fresh checkout. It creates the virtual environment at `venv/`, but every following line installs into `${VENV}`, which defaults to `.venv/`:

```
$ git clone https://github.com/jsvine/pdfplumber.git && cd pdfplumber
$ make venv
python3 -m venv venv
.venv/bin/pip install --upgrade pip
make: .venv/bin/pip: No such file or directory
make: *** [venv] Error 1
```

This came in with ec96f72, which parameterized the rest of the Makefile onto the new `VENV` variable but left the `python3 -m venv venv` line hardcoded.

The one-line fix makes the creation line use the same variable as everything else.

It also makes the `VENV` variable work as intended. Previously `make venv VENV=custom-env` would create `venv/` and then try to install into a `custom-env/` that was never created; now the override is honored end-to-end:

```
$ make -n venv VENV=custom-env
python3 -m venv custom-env
custom-env/bin/pip install --upgrade pip
...
```

Verified on a clean clone of `develop`: the failure above reproduces before the change, and after it `make venv` completes and `make tests` runs green (172 passed) in the environment it creates.

No contributor-list entry here, since #1387 already adds one and I'd rather not create a conflict between the two branches.
