### PR TITLE
Fix PDF.close() closing the wrong Page instances (memory leak, #1339)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 ## [Unreleased]
 
 ### Fixed
+- Fix `PDF.close()` closing the wrong `Page` instances: it called `flush_cache()` (which clears the cached `_pages` list) before iterating `self.pages`, so that iteration re-parsed and closed a fresh, never-otherwise-referenced set of pages instead of the ones the caller actually used — leaving the real pages' `_objects`/`_layout`/`get_textmap` caches unreleased. This caused unbounded-seeming memory growth in long-lived processes that open many PDFs sequentially. ([#1339](https://github.com/jsvine/pdfplumber/issues/1339), related: [#1229](https://github.com/jsvine/pdfplumber/issues/1229), [#1189](https://github.com/jsvine/pdfplumber/issues/1189))
 - Initialize PDFium's form environment in `get_page_image` so that filled AcroForm field content is included when rendering pages via `Page.to_image()`. ([#1367](https://github.com/jsvine/pdfplumber/issues/1367))
 - Fix `make venv`, which created the virtual environment at `venv/` but then installed into `${VENV}` (default `.venv/`), causing the target to fail on a fresh checkout (h/t @soodoku). ([ec96f72](https://github.com/jsvine/pdfplumber/commit/ec96f72))
 - Include the wrapped exception's class name in `PdfminerException`'s message when `pdfminer.six` raises an exception without one (e.g. `PDFPasswordIncorrect`), which previously surfaced as a blank error message.

--- a/README.md
+++ b/README.md
@@ -577,6 +577,7 @@ Many thanks to the following users who've contributed ideas, features, and fixes
 - [Sebastian Cao](https://github.com/cycsmail)
 - [Kaspar Naraghi](https://github.com/kaninaba94)
 - [Siddharth Gaur](https://github.com/siddharthgaur1)
+- [Timothy O'Hare](https://github.com/timothyohare)
 
 ## Contributing
 

--- a/pdfplumber/pdf.py
+++ b/pdfplumber/pdf.py
@@ -122,10 +122,15 @@ class PDF(Container):
             raise
 
     def close(self) -> None:
-        self.flush_cache()
-
+        # Must close the pages *before* flush_cache() clears `_pages`; the
+        # `pages` property re-parses (and returns a fresh, never-otherwise-
+        # referenced set of pages) if `_pages` is missing, so flushing first
+        # means the pages actually used by the caller never get their heavy
+        # caches (`_objects`, `_layout`, `get_textmap`) released. See #1339.
         for page in self.pages:
             page.close()
+
+        self.flush_cache()
 
         if not self.stream_is_external:
             self.stream.close()

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -338,3 +338,26 @@ class Test(unittest.TestCase):
         ):
             for _ in pdf.annots:
                 pass
+
+    def test_issue_1339(self):
+        """
+        PDF.close() closed the wrong Page instances: flush_cache() ran
+        first and deleted the cached `_pages` list, so the subsequent
+        `for page in self.pages: page.close()` re-parsed and closed a
+        fresh, never-otherwise-referenced set of pages instead of the ones
+        the caller actually used -- leaving the real pages' `_objects` /
+        `_layout` / `get_textmap` caches unreleased after close().
+        https://github.com/jsvine/pdfplumber/issues/1339
+        """
+        path = os.path.join(HERE, "pdfs/issue-33-lorem-ipsum.pdf")
+        pdf = pdfplumber.open(path)
+        pages = pdf.pages
+        for page in pages:
+            page.extract_text()
+            assert hasattr(page, "_objects")
+
+        pdf.close()
+
+        for page in pages:
+            assert not hasattr(page, "_objects")
+            assert page.get_textmap.cache_info().currsize == 0


### PR DESCRIPTION
## Summary

Fixes #1339 (and the same underlying issue as #1229 and #1189): `PDF.close()`
doesn't actually release the pages it's supposed to.

`close()` currently does:

```python
def close(self) -> None:
    self.flush_cache()

    for page in self.pages:
        page.close()
    ...
```

`flush_cache()` clears `PDF.cached_properties`, which includes `_pages`. So
by the time `for page in self.pages` runs, `_pages` no longer exists, and the
`pages` property's fallback branch re-parses the document from scratch
(`PDFPage.create_pages(self.doc)`), builds a brand-new list of `Page`
objects, and closes *those*. The pages the caller actually used --
e.g. via `for page in pdf.pages: page.extract_text()` -- are never closed at
all.

Since those real pages are never closed, their per-page caches (`_objects`,
`_layout`, and the `get_textmap` lru_cache result) are never released. In a
long-lived process that opens many PDFs sequentially, this shows up as
memory that appears to grow without bound rather than being freed when each
`with pdfplumber.open(...)` block exits -- reported independently by three
different users (#1339, #1229, #1189), including one (#1339) who traced it
to this exact line pair in `close()`.

## Fix

Swap the order: close the pages (while `self.pages` still returns the ones
actually used) *before* flushing the cache that `self.pages` depends on.

```python
def close(self) -> None:
    for page in self.pages:
        page.close()

    self.flush_cache()
    ...
```

This is a 3-line reorder, no behavior change other than closing the correct
objects.

## Test plan

- [x] Added `test_issue_1339` in `tests/test_issues.py`: opens a PDF, forces
      each page's `_objects` cache to populate via `extract_text()`, calls
      `pdf.close()`, then asserts the *original* page objects (the ones the
      caller held references to) had `_objects` cleared and
      `get_textmap.cache_info().currsize == 0`.
- [x] Verified the test fails on the current `develop` ordering
      (`assert not hasattr(page, "_objects")` → `AssertionError: assert not True`)
      and passes with the fix.
- [x] Full suite: `python -m pytest tests/` -- 174 passed (175 with the new test).
- [x] `black --check`, `flake8` clean on changed files. (Pre-existing note:
      `isort --check pdfplumber/pdf.py` reports an unrelated, pre-existing
      diff on this file's `typing` import line that's present on `develop`
      before this change too -- not touched by this PR.)

Found this while root-causing an OOM in a personal project's daily cron job
(pdfplumber 0.11.10) that parses a few hundred ASX regulatory PDFs
sequentially in one process -- happy to share more detail on that
reproduction if useful.