### PR TITLE
fix encoding fallback in Serializer.do_bytes

### DIFF
--- a/pdfplumber/convert.py
+++ b/pdfplumber/convert.py
@@ -119,8 +119,8 @@ class Serializer:
         for e in ENCODINGS_TO_TRY:
             try:
                 return obj.decode(e)
-            except UnicodeDecodeError:  # pragma: no cover
-                return None
+            except UnicodeDecodeError:
+                continue
         # If none of the decodings work, raise whatever error
         # decoding with utf-8 causes
         obj.decode(ENCODINGS_TO_TRY[0])  # pragma: no cover

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -173,6 +173,15 @@ class Test(unittest.TestCase):
             c = json.loads(pdf.to_json())
             assert len(c["pages"][0]["images"])
 
+    def test_serialize_bytes_encoding_fallback(self):
+        from pdfplumber.convert import Serializer
+
+        s = Serializer()
+        # Bytes that are not valid UTF-8 but decode under a later
+        # encoding in the fallback list must not be dropped to None.
+        assert s.do_bytes(b"\xff\xfe\x41") == "\xff\xfe\x41"
+        assert s.serialize(b"\xff\xfe\x41") == "\xff\xfe\x41"
+
     def test_csv(self):
         c = self.pdf.to_csv(precision=3)
         assert c.split("\r\n")[9] == (


### PR DESCRIPTION
`do_bytes` is meant to walk `ENCODINGS_TO_TRY`, but the handler returns on the first failure:

    >>> Serializer().do_bytes(b"\xff\xfe\x41")
    None          # latin-1 decodes this to "\xff\xfe\x41"

So only utf-8 is ever attempted. Any PDF-supplied byte field that isn't valid utf-8 (font names, text, PSLiteral values) is dropped to `null` in `to_json`/`to_csv` output instead of falling through to latin-1/utf-16. Switching the early `return None` to `continue` lets the rest of the list run; the trailing re-raise stays as the last resort.