### PR TITLE
fix: keep layout superscripts aligned with baseline numbers

### DIFF
--- a/pdfplumber/utils/text.py
+++ b/pdfplumber/utils/text.py
@@ -341,10 +341,18 @@ class WordMap:
             else sorted(self.tuples, key=lambda x: line_cluster_key(x[0]))
         )
 
+        # Keep superscripts (slightly smaller `top`) on the same layout
+        # line as the baseline so their x-position is not computed alone.
+        if layout:
+            line_density = y_density if line_dir in ("ttb", "btt") else x_density
+            line_cluster_tolerance = max(y_tolerance, line_density / 2)
+        else:
+            line_cluster_tolerance = y_tolerance
+
         tuples_by_line = cluster_objects(
             words_sorted_line_dir,
             lambda x: line_cluster_key(x[0]),
-            y_tolerance,
+            line_cluster_tolerance,
             preserve_order=presorted or use_text_flow,
         )
 
@@ -374,7 +382,7 @@ class WordMap:
 
             line_tuples_sorted = (
                 line_tuples
-                if presorted or use_text_flow
+                if use_text_flow or (presorted and not layout)
                 else sorted(line_tuples, key=lambda x: char_sort_key(x[0]))
             )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -417,6 +417,76 @@ class Test(unittest.TestCase):
         with pytest.raises(ValueError):
             p.extract_text(layout=True, layout_height=300, layout_height_chars=50)
 
+    def test_extract_text_layout_superscript_asterisk_x_position(self):
+        """
+        Superscript '*' just above a baseline number (issue 1380) must keep
+        its x-position in layout=True output: after the number it annotates,
+        not shifted left on a previous line.
+        """
+
+        def make_char(text, x0, top, width=6.0, size=12.0):
+            return {
+                "text": text,
+                "x0": x0,
+                "x1": x0 + width,
+                "top": top,
+                "doctop": top,
+                "bottom": top + size,
+                "width": width,
+                "height": size,
+                "size": size,
+                "upright": True,
+            }
+
+        # Narrow glyphs to the left make line_len outrun x/x_density, which
+        # is what leaves isolated superscripts shifted left of "328"/"329".
+        baseline_top = 100.0
+        super_top = baseline_top - 3.4
+        chars = []
+        x = 10.0
+        for letter in "AgainstCelsus":
+            chars.append(make_char(letter, x, baseline_top, width=5.0))
+            x += 5.0
+        for i, digit in enumerate("328"):
+            chars.append(make_char(digit, 90.0 + i * 6.0, baseline_top))
+        chars.append(make_char("*", 111.0, super_top))
+        for i, digit in enumerate("329"):
+            chars.append(make_char(digit, 123.0 + i * 6.0, baseline_top))
+        chars.append(make_char("*", 144.0, super_top))
+
+        text = utils.extract_text(
+            chars,
+            layout=True,
+            layout_width=250,
+            layout_height=130,
+            layout_bbox=(0, 0, 250, 130),
+        )
+        lines = [line for line in text.split("\n") if line.strip()]
+        combined = "\n".join(lines)
+        assert "328" in combined and "329" in combined
+        assert combined.count("*") == 2
+
+        star_cols = []
+        num_cols = {}
+        for line in lines:
+            pos = 0
+            while True:
+                found = line.find("*", pos)
+                if found < 0:
+                    break
+                star_cols.append(found)
+                pos = found + 1
+            for number in ("328", "329"):
+                found = line.find(number)
+                if found >= 0:
+                    num_cols[number] = found
+
+        assert "328" in num_cols and "329" in num_cols
+        assert len(star_cols) == 2
+        # Each '*' is at or after the end of the number it annotates.
+        assert star_cols[0] >= num_cols["328"] + 3
+        assert star_cols[1] >= num_cols["329"] + 3
+
     def test_extract_text_nochars(self):
         charless = self.pdf.pages[0].filter(lambda df: df["object_type"] != "char")
         assert charless.extract_text() == ""


### PR DESCRIPTION
## Summary

With `extract_text(layout=True)`, a superscript `*` sitting just above a baseline number (common footnote / citation markers) was clustered onto its own layout line. That line kept raw PDF x-columns while the baseline line drifted right, so the markers appeared shifted left of `328` / `329` (issue PDF: Against Celsus line).

Two small layout-only adjustments:
1. Widen vertical line clustering for `layout=True` with `max(y_tolerance, line_density / 2)` so near-baseline superscripts share a line with the text they annotate.
2. X-sort words on layout lines even when `presorted=True`, so extraction order cannot leave `*` before the number it belongs to. `use_text_flow` is unchanged.

## Test plan

- [x] `pytest tests/test_utils.py` (37 passed), including new synthetic superscript layout regression
- [x] Reproduced on the issue's `page826.pdf`: one line `Against Celsus (Origen), 327 , 328 * , 329 *`

Fixes #1380