### PR TITLE
Update y0/y1 when clipping objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. The format 
 - Initialize PDFium's form environment in `get_page_image` so that filled AcroForm field content is included when rendering pages via `Page.to_image()`. ([#1367](https://github.com/jsvine/pdfplumber/issues/1367))
 - Fix `make venv`, which created the virtual environment at `venv/` but then installed into `${VENV}` (default `.venv/`), causing the target to fail on a fresh checkout (h/t @soodoku). ([ec96f72](https://github.com/jsvine/pdfplumber/commit/ec96f72))
 - Include the wrapped exception's class name in `PdfminerException`'s message when `pdfminer.six` raises an exception without one (e.g. `PDFPasswordIncorrect`), which previously surfaced as a blank error message.
+- Update `y0`/`y1` in `utils.clip_obj` (and therefore `Page.crop(...)`), which previously adjusted only `top`/`bottom`/`height`/`doctop`, leaving the bottom-up coordinates of clipped objects at their pre-crop values.
 
 ## [0.11.10] — 2026-06-14
 

--- a/README.md
+++ b/README.md
@@ -577,6 +577,7 @@ Many thanks to the following users who've contributed ideas, features, and fixes
 - [Sebastian Cao](https://github.com/cycsmail)
 - [Kaspar Naraghi](https://github.com/kaninaba94)
 - [Siddharth Gaur](https://github.com/siddharthgaur1)
+- [Dylan Pulver](https://github.com/dylanpulver)
 
 ## Contributing
 

--- a/pdfplumber/utils/geometry.py
+++ b/pdfplumber/utils/geometry.py
@@ -87,6 +87,12 @@ def clip_obj(obj: T_obj, bbox: T_bbox) -> Optional[T_obj]:
     diff = dims["top"] - obj["top"]
     if "doctop" in copy:
         copy["doctop"] = obj["doctop"] + diff
+    # `y0`/`y1` are measured up from the bottom of the page, so they move in
+    # the opposite direction to `top`/`bottom`, as in `resize_object`.
+    if "y1" in copy:
+        copy["y1"] = obj["y1"] - diff
+    if "y0" in copy:
+        copy["y0"] = obj["y0"] - (dims["bottom"] - obj["bottom"])
     copy["width"] = copy["x1"] - copy["x0"]
     copy["height"] = copy["bottom"] - copy["top"]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -623,6 +623,34 @@ class Test(unittest.TestCase):
             "y1": 50,
         }
 
+    def test_clip_obj(self):
+        obj = {
+            "x0": 5,
+            "x1": 10,
+            "top": 20,
+            "bottom": 30,
+            "width": 5,
+            "height": 10,
+            "doctop": 120,
+            "y0": 40,
+            "y1": 50,
+        }
+        # Clipping the top and the bottom should move `y1`/`y0` by the same
+        # amounts, in the opposite direction, as `resize_object` does.
+        assert utils.clip_obj(obj, (0, 25, 100, 28)) == {
+            "x0": 5,
+            "x1": 10,
+            "top": 25,
+            "bottom": 28,
+            "width": 5,
+            "height": 3,
+            "doctop": 125,
+            "y0": 42,
+            "y1": 45,
+        }
+        # A clip that does not cross the object leaves it unchanged.
+        assert utils.clip_obj(obj, (0, 0, 100, 100)) == obj
+
     def test_move_object(self):
         a = {
             "x0": 5,


### PR DESCRIPTION
`utils.clip_obj` updates `top`, `bottom`, `height` and `doctop` but not `y0`/`y1`, so an object that straddles a `Page.crop(...)` boundary keeps its pre-crop bottom-up coordinates.

On `tests/pdfs/pdffill-demo.pdf` (792pt tall), cropping through the middle of the first char:

```
before crop  top=117.18 bottom=135.18  y0=656.82 y1=674.82  height=18.0
after  crop  top=126.18 bottom=135.18  y0=656.82 y1=674.82  height=9.0
```

`y1 - y0` is 18.0 while `height` is 9.0. The README documents `y1` as the distance of the object's top from the bottom of the page, i.e. 792 - 126.18 = 665.82.

The two sibling helpers in the same module already handle this: `resize_object` does `y1 -= diff` for `top` and `y0 -= diff` for `bottom`, and `move_object` shifts both. This applies the same convention in `clip_obj`.

How I found it: reading `utils/geometry.py` for helpers that maintain the two coordinate systems inconsistently — not from a PDF in hand. `clip_obj` is the only one of the three that touches `top`/`bottom` without touching `y0`/`y1`. `geometry.py` reports 100% line coverage and `test_resize_object` asserts the `y0`/`y1` behaviour explicitly, but there was no unit test for `clip_obj`.

Measured: `python -m pytest tests/` → 174 passed on this branch, 173 before. Reverting only `geometry.py` and keeping the new test → 1 failed / 173 passed, differing on `y0` and `y1`. A naive variant that shifts both `y0` and `y1` by the `top` delta also fails, on `y0`.

Not addressed: `clip_obj` still leaves a curve's `pts` list uncropped, and `curve_to_edges` output carries no `y0`/`y1` at all. `black`, `isort`, `flake8` and `mypy --strict` are clean; I did not run the notebook examples.

Disclosure: this patch was written with AI assistance (Claude).
