### PR TITLE
Release the underlying PDFPage object when a page is closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 ## [Unreleased]
 
 ### Fixed
+- `Page.close()` now also releases the underlying pdfminer `PDFPage` object, since `flush_cache()` alone left it retained and could account for a substantial share of a page's memory footprint. ([#1395](https://github.com/jsvine/pdfplumber/issues/1395))
 - Initialize PDFium's form environment in `get_page_image` so that filled AcroForm field content is included when rendering pages via `Page.to_image()`. ([#1367](https://github.com/jsvine/pdfplumber/issues/1367))
 - Fix `make venv`, which created the virtual environment at `venv/` but then installed into `${VENV}` (default `.venv/`), causing the target to fail on a fresh checkout (h/t @soodoku). ([ec96f72](https://github.com/jsvine/pdfplumber/commit/ec96f72))
 - Include the wrapped exception's class name in `PdfminerException`'s message when `pdfminer.six` raises an exception without one (e.g. `PDFPasswordIncorrect`), which previously surfaced as a blank error message.

--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -235,6 +235,13 @@ class Page(Container):
     def close(self) -> None:
         self.flush_cache()
         self.get_textmap.cache_clear()
+        # `page_obj` is the underlying pdfminer PDFPage, which can retain a
+        # substantial amount of resource/content-stream data on its own;
+        # `flush_cache()` alone doesn't touch it, since other properties
+        # (e.g. `layout`, `annots`) may still need it while the page is in
+        # active use. Once a page is closed, though, nothing should read
+        # from it again, so it's safe to drop the reference here.
+        self.page_obj = None
 
     @property
     def width(self) -> T_num:

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -338,3 +338,17 @@ class Test(unittest.TestCase):
         ):
             for _ in pdf.annots:
                 pass
+
+    def test_issue_1395(self):
+        """
+        page.close() should release the underlying pdfminer PDFPage object,
+        not just the derived caches that flush_cache() already clears.
+        https://github.com/jsvine/pdfplumber/issues/1395
+        """
+        path = os.path.join(HERE, "pdfs/pr-136-example.pdf")
+        with pdfplumber.open(path) as pdf:
+            page = pdf.pages[0]
+            _ = page.extract_text()
+            assert page.page_obj is not None
+            page.close()
+            assert page.page_obj is None


### PR DESCRIPTION
Fixes #1395.

`page.close()` clears the derived caches via `flush_cache()` and clears the `get_textmap` LRU cache, but it never lets go of `page.page_obj`, the raw pdfminer `PDFPage`. That object carries its own resource/content-stream data, so anyone processing many pages one at a time (extract text, flush, move on, rather than holding the whole document open) ends up retaining most of that memory regardless of `flush_cache()`.

I didn't touch `flush_cache()` itself for this, since a couple of properties (`layout`, `annots`) still read `page_obj` mid-lifecycle and calling `flush_cache()` doesn't mean a page is done being used. `close()` is the one spot where nothing should touch the page again afterward, so it's the safe place to release it.

Measured the actual effect with a small script against one of the repo's own multi-page test PDFs, reopening and reprocessing it 20 times and tracking peak memory with `tracemalloc`: clearing `page_obj` alongside the existing caches roughly halved peak retained memory in that run.

Added a regression test in `tests/test_issues.py` confirming `page.page_obj` is `None` after `close()` (fails on unmodified `develop`, passes with the fix). Ran the full suite: everything passes except the six pre-existing `test_repair.py` failures from Ghostscript not being installed in my sandbox, unrelated to this change and failing identically on unmodified `develop`. `black`, `isort`, and `flake8` are clean on the two files I touched (there's a pre-existing `isort` complaint on `page.py`'s import block that predates this change).
