### PR TITLE
Clear the textmap cache in Page.flush_cache()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. The format 
 - Initialize PDFium's form environment in `get_page_image` so that filled AcroForm field content is included when rendering pages via `Page.to_image()`. ([#1367](https://github.com/jsvine/pdfplumber/issues/1367))
 - Fix `make venv`, which created the virtual environment at `venv/` but then installed into `${VENV}` (default `.venv/`), causing the target to fail on a fresh checkout (h/t @soodoku). ([ec96f72](https://github.com/jsvine/pdfplumber/commit/ec96f72))
 - Include the wrapped exception's class name in `PdfminerException`'s message when `pdfminer.six` raises an exception without one (e.g. `PDFPasswordIncorrect`), which previously surfaced as a blank error message.
+- Clear the textmap cache in `Page.flush_cache()`. That cache is not a `cached_properties` entry, so it survived the flush, even though it is the largest of a page's caches: on a 65-page test PDF, `flush_cache()` released 79 MB where `close()` released 180 MB. ([#1395](https://github.com/jsvine/pdfplumber/issues/1395))
 
 ## [0.11.10] — 2026-06-14
 

--- a/pdfplumber/page.py
+++ b/pdfplumber/page.py
@@ -232,9 +232,14 @@ class Page(Container):
         # See https://rednafi.com/python/lru_cache_on_methods/
         self.get_textmap = lru_cache()(self._get_textmap)
 
+    def flush_cache(self, properties: Optional[List[str]] = None) -> None:
+        super().flush_cache(properties)
+        # The textmap cache is by far the largest of a Page's caches, and is
+        # not a `cached_properties` entry, so it has to be cleared explicitly.
+        self.get_textmap.cache_clear()
+
     def close(self) -> None:
         self.flush_cache()
-        self.get_textmap.cache_clear()
 
     @property
     def width(self) -> T_num:
@@ -650,8 +655,9 @@ class DerivedPage(Page):
         self.rotation = parent_page.rotation
         self.mediabox = parent_page.mediabox
         self.cropbox = parent_page.cropbox
-        self.flush_cache(Container.cached_properties)
+        # Must precede flush_cache, which now clears this cache.
         self.get_textmap = lru_cache()(self._get_textmap)
+        self.flush_cache(Container.cached_properties)
 
 
 def test_proposed_bbox(bbox: T_bbox, parent_bbox: T_bbox) -> None:

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -262,3 +262,25 @@ class Test(unittest.TestCase):
             assert page.artbox == (42.51969, 70.86613999999997, 552.75591, 827.71653)
             assert page.bleedbox == (0, 0.0, 623.62205, 870.23622)
             assert page.trimbox == (28.34646, 56.69290999999998, 566.92913, 841.88976)
+
+    def test_flush_cache_clears_textmap(self):
+        """Page.flush_cache() should release the textmap cache, which is the
+        largest of a page's caches and is not a `cached_properties` entry."""
+        path = os.path.join(HERE, "pdfs/nics-background-checks-2015-11.pdf")
+        with pdfplumber.open(path) as pdf:
+            page = pdf.pages[0]
+            page.extract_text()
+            assert page.get_textmap.cache_info().currsize == 1
+            assert hasattr(page, "_layout")
+
+            page.flush_cache()
+            assert page.get_textmap.cache_info().currsize == 0
+            assert not hasattr(page, "_layout")
+
+            # ... and a cropped page, whose textmap cache is built after its
+            # constructor calls flush_cache(Container.cached_properties)
+            cropped = pdf.pages[0].crop((0, 0, 100, 100))
+            cropped.extract_text()
+            assert cropped.get_textmap.cache_info().currsize == 1
+            cropped.flush_cache()
+            assert cropped.get_textmap.cache_info().currsize == 0


### PR DESCRIPTION
Fixes #1395.

## Problem

`Page.flush_cache()` iterates `Page.cached_properties`, which covers `_layout` and the object/edge caches — but not the `lru_cache` wrapping `_get_textmap`, which is created as an instance attribute in `Page.__init__` and is the largest of a page's caches. So a flush left most of the memory in place.

Measured on `tests/pdfs/chelsea_pdta.pdf` (65 pages), calling `extract_text()` on every page under `tracemalloc`:

| | traced memory |
|---|---|
| no flush | 184.61 MB |
| `flush_cache()` — before this PR | 105.19 MB |
| `close()` | 4.80 MB |
| `flush_cache()` — after this PR | 4.80 MB |

## Note on the issue's diagnosis

The report attributes the retention to `_layout` surviving the flush and to `page_obj`, and proposes `page.page_obj = None` as the fix. Neither holds up:

- `_layout` **is** cleared already. `flush_cache` reads `self.cached_properties`, which on a `Page` resolves to `Container.cached_properties + ["_layout"]`, so the default flush includes it.
- `page.page_obj = None` changes nothing measurable (105.19 MB → 105.19 MB). The entire difference is the textmap cache.

The retention the reporter measured is real; the cause is the textmap cache.

## Change

- `Page.flush_cache()` now clears the textmap cache after delegating to `Container.flush_cache`.
- `Page.close()` did this explicitly already, so it now just delegates to `flush_cache()`.
- `DerivedPage.__init__` builds its textmap cache *before* calling `flush_cache()` rather than after, since `flush_cache()` now touches that attribute. Without the reorder, constructing any cropped page raises `AttributeError`.

Users who want the old surgical behaviour can still pass an explicit list, e.g. `page.flush_cache(["_objects"])` — the textmap cache is cleared either way, which matches what the method's name promises.

## Tests

Adds `test_flush_cache_clears_textmap`, covering both an original page and a cropped one (the `DerivedPage` path that the reorder protects). It fails on the parent commit (`assert 1 == 0`) and passes with the change.

Full suite: 164 passed, 10 failed — all 10 failures are pre-existing on a clean `develop` in this environment (`test_repair.py` needs Ghostscript, `test_convert.py` hits Windows line-ending differences) and are unrelated to this change.

`black`, `isort --profile black`, `flake8` and `mypy` all pass on the touched files.
